### PR TITLE
AWS dart fixes

### DIFF
--- a/darts/aws_full.yaml
+++ b/darts/aws_full.yaml
@@ -5,6 +5,7 @@
 
 tofu_main_directory: ./tofu/main/aws
 #tofu_parallelism: 10
+
 tofu_variables:
 #  project_name: st
 #  region: us-east-1
@@ -58,21 +59,26 @@ tofu_variables:
 #  first_app_https_port: 9443
 
 chart_variables:
-  rancher_replicas: 3
-  downstream_rancher_monitoring: true
-  #  admin_password: adminadminadmin
-  rancher_version: 2.8.6
-  #  rancher_image_override: rancher/rancher
-  #  rancher_image_tag_override: v2.8.6-debug-1
-  #  force_prime_registry: false
-  # see https://github.com/rancher/charts/tree/release-v2.8/assets/rancher-monitoring-crd
-  rancher_monitoring_version: 103.1.1+up45.31.1
+#  rancher_replicas: 1
+#  downstream_rancher_monitoring: true
+#  admin_password: adminadminadmin
+#  rancher_monitoring_version: 104.1.0+up57.0.3 # see https://github.com/rancher/charts/tree/release-v2.9/assets/rancher-monitoring-crd
 #  cert_manager_version: 1.8.0
 #  tester_grafana_version: 6.56.5
+#  rancher_version: 2.9.1
+#  force_prime_registry: false
+
+# Use the following for 2.8.6:
+#  rancher_version: 2.8.6
+#  rancher_monitoring_version: 103.1.1+up45.31.1 # see https://github.com/rancher/charts/tree/release-v2.8/assets/rancher-monitoring-crd
+
+# Add the following to set a custom image:
+#  rancher_image_override: rancher/rancher
+#  rancher_image_tag_override: v2.8.6-debug-1
 
 test_variables:
-  test_config_maps: 2000
-  test_secrets: 2000
-  test_roles: 20
-  test_users: 10
-  test_projects: 20
+#  test_config_maps: 2000
+#  test_secrets: 2000
+#  test_roles: 20
+#  test_users: 10
+#  test_projects: 20

--- a/darts/aws_full.yaml
+++ b/darts/aws_full.yaml
@@ -6,56 +6,56 @@
 tofu_main_directory: ./tofu/main/aws
 #tofu_parallelism: 10
 tofu_variables:
-  project_name: st
-  region: us-east-1
-  availability_zone: us-east-1a
-  aws_profile: rancher-eng
-  ssh_private_key_path: ~/.ssh/id_ed25519
-  ssh_public_key_path: ~/.ssh/id_ed25519.pub
-  ssh_user: root
-  ssh_bastion_user: root
-  bastion_host_ami: ami-0e55a8b472a265e3f # openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
+#  project_name: st
+#  region: us-east-1
+#  availability_zone: us-east-1a
+#  aws_profile: null
+#  ssh_public_key_path: ~/.ssh/id_ed25519.pub
+#  ssh_private_key_path: ~/.ssh/id_ed25519
+#  ssh_user: root
+#  ssh_bastion_user: root
+#  bastion_host_ami: ami-0e55a8b472a265e3f # openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
 
-  upstream_cluster:
-    name_prefix: upstream
-    server_count: 1
-    agent_count: 0
-    distro_version: v1.26.9+k3s1
-    public_ip: true
-    reserve_node_for_monitoring: false
-    # aws-specific
-    instance_type: i3.large
-    instance_tags: { Owner: st, DoNotDelete: true }
-    ami: ami-009fd8a4732ea789b # openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
+#  upstream_cluster:
+#    name_prefix: upstream
+#    server_count: 1
+#    agent_count: 0
+#    distro_version: v1.26.9+k3s1
+#    public_ip: true
+#    reserve_node_for_monitoring: false
+#    # aws-specific
+#    instance_type: i3.large
+#    instance_tags: { Owner: st, DoNotDelete: true }
+#    ami: ami-009fd8a4732ea789b # openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
 
-  deploy_tester_cluster: true
-  tester_cluster:
-    name_prefix: tester
-    server_count: 1
-    agent_count: 0
-    distro_version: v1.26.9+k3s1
-    public_ip: true
-    reserve_node_for_monitoring: false
-    # aws-specific
-    instance_type: t3a.large
-    instance_tags: { Owner: st, DoNotDelete: true }
-    ami: ami-009fd8a4732ea789b # openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
+#  deploy_tester_cluster: true
+#  tester_cluster:
+#    name_prefix: tester
+#    server_count: 1
+#    agent_count: 0
+#    distro_version: v1.26.9+k3s1
+#    public_ip: false
+#    reserve_node_for_monitoring: false
+#    # aws-specific
+#    instance_type: t3a.large
+#    instance_tags: { Owner: st, DoNotDelete: true }
+#    ami: ami-009fd8a4732ea789b # openSUSE-Leap-15-5-v20230608-hvm-ssd-x86_64
 
-  downstream_cluster_templates:
-    - cluster_count: 0 # defaults to 0 to keep in-line with previous behavior
-      name_prefix: first
-      server_count: 1
-      agent_count: 0
-      distro_version: v1.26.9+k3s1
-      public_ip: false
-      reserve_node_for_monitoring: false
-      # aws-specific
-      instance_type: t4g.large
-      instance_tags: { Owner: st, DoNotDelete: true }
-      ami: ami-0e55a8b472a265e3f # openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
-  first_kubernetes_api_port: 7445
-  first_app_http_port: 9080
-  first_app_https_port: 9443
+#  downstream_cluster_templates:
+#    - cluster_count: 0
+#      name_prefix: downstream
+#      server_count: 1
+#      agent_count: 0
+#      distro_version: v1.26.9+k3s1
+#      public_ip: false
+#      reserve_node_for_monitoring: false
+#      # aws-specific
+#      instance_type: t4g.large
+#      instance_tags: { Owner: st, DoNotDelete: true }
+#      ami: ami-0e55a8b472a265e3f # openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
+#  first_kubernetes_api_port: 7445
+#  first_app_http_port: 9080
+#  first_app_https_port: 9443
 
 chart_variables:
   rancher_replicas: 3

--- a/darts/aws_full.yaml
+++ b/darts/aws_full.yaml
@@ -3,7 +3,7 @@
 # all available variables are represented in this file
 # commented out lines show defaults
 
-tofu_main_directory: /home/ivln/workspace/work/RancherVCS/scalability-tests/tofu/main/aws
+tofu_main_directory: ./tofu/main/aws
 #tofu_parallelism: 10
 tofu_variables:
   project_name: st

--- a/darts/aws_simple.yaml
+++ b/darts/aws_simple.yaml
@@ -1,11 +1,9 @@
 # Deploys Rancher from (mostly) defaults
-# see k3d_full.yaml for more configuration options
+# see aws_full.yaml for more configuration options
 
-tofu_main_directory: ./tofu/main/k3d
+tofu_main_directory: ./tofu/main/aws
 
 tofu_variables:
-  downstream_cluster_count: 0
-  distro_version: v1.26.9+k3s1
 
 chart_variables:
   rancher_replicas: 1

--- a/darts/k3d_full.yaml
+++ b/darts/k3d_full.yaml
@@ -5,6 +5,7 @@
 
 tofu_main_directory: ./tofu/main/k3d
 #tofu_parallelism: 10
+
 tofu_variables:
 #  downstream_cluster_count: 0
 #  distro_version: v1.26.9+k3s1
@@ -23,21 +24,24 @@ tofu_variables:
 #  first_app_https_port: 8443
 
 chart_variables:
-  rancher_replicas: 3
-  downstream_rancher_monitoring: true
+#  rancher_replicas: 1
+#  downstream_rancher_monitoring: true
 #  admin_password: adminadminadmin
-  rancher_version: 2.8.6
-#  rancher_image_override: rancher/rancher
-#  rancher_image_tag_override: v2.8.6-debug-1
-#  force_prime_registry: false
-# see https://github.com/rancher/charts/tree/release-v2.8/assets/rancher-monitoring-crd
-  rancher_monitoring_version: 103.1.1+up45.31.1
 #  cert_manager_version: 1.8.0
 #  tester_grafana_version: 6.56.5
+#  force_prime_registry: false
+
+# Use the following for 2.8.6:
+#  rancher_version: 2.8.6
+#  rancher_monitoring_version: 103.1.1+up45.31.1 # see https://github.com/rancher/charts/tree/release-v2.8/assets/rancher-monitoring-crd
+
+# Add the following to set a custom image:
+#  rancher_image_override: rancher/rancher
+#  rancher_image_tag_override: v2.8.6-debug-1
 
 test_variables:
-  test_config_maps: 2000
-  test_secrets: 2000
-  test_roles: 20
-  test_users: 10
-  test_projects: 20
+#  test_config_maps: 2000
+#  test_secrets: 2000
+#  test_roles: 20
+#  test_users: 10
+#  test_projects: 20

--- a/internal/dart/recipe.go
+++ b/internal/dart/recipe.go
@@ -48,10 +48,17 @@ var defaultDart = Dart{
 		RancherReplicas:             1,
 		DownstreamRancherMonitoring: false,
 		AdminPassword:               "adminadminadmin",
-		RancherVersion:              "2.8.5",
-		RancherMonitoringVersion:    "103.0.0+up45.31.1",
+		RancherVersion:              "2.9.1",
+		RancherMonitoringVersion:    "104.1.0+up57.0.3",
 		CertManagerVersion:          "1.8.0",
 		TesterGrafanaVersion:        "6.56.5",
+	},
+	TestVariables: TestVariables{
+		TestConfigMaps: 2000,
+		TestSecrets:    2000,
+		TestRoles:      20,
+		TestUsers:      10,
+		TestProjects:   20,
 	},
 }
 

--- a/tofu/main/aws/main.tf
+++ b/tofu/main/aws/main.tf
@@ -1,7 +1,6 @@
 provider "aws" {
   region = var.region
-  profile =  length(var.aws_profile) > 0 ? var.aws_profile : null
-
+  profile =  var.aws_profile
 }
 
 module "network" {

--- a/tofu/main/aws/variables.tf
+++ b/tofu/main/aws/variables.tf
@@ -6,7 +6,8 @@ variable "region" {
 
 variable "aws_profile" {
   description = "Local ~/.aws/config profile to utilize for AWS access"
-  default = ""
+  type = string
+  default = null
 }
 
 variable "availability_zone" {
@@ -32,7 +33,6 @@ variable "ssh_private_key_path" {
 
 variable "ssh_user" {
   description = "User name to use for the SSH connection"
-  type        = string
   default     = "root"
 }
 
@@ -135,7 +135,7 @@ variable "tester_cluster" {
     server_count   = 1
     agent_count    = 0
     distro_version = "v1.26.9+k3s1"
-    public_ip = true
+    public_ip = false
     reserve_node_for_monitoring = false
 
     // aws-specific


### PR DESCRIPTION
This:

1.  uniforms darts: _full darts should contain all defaults commented out, but they didn't
2. bumps Rancher to 2.9.1 for all of them
3. adds an aws_simple.yaml dart which is meant to be as bare-bones, fool-proof as possible

Best reviewed commit-by-commit

CI failures addressed in https://github.com/rancher/dartboard/pull/4