### PR TITLE
Fix Rancher monitoring deployment errors

### DIFF
--- a/cmd/dartboard/subcommands/deploy.go
+++ b/cmd/dartboard/subcommands/deploy.go
@@ -101,7 +101,7 @@ func Deploy(cli *cli.Context) error {
 		return err
 	}
 
-	// Wait Rancher Deployment to be complete, or subsequent steps may fail
+	// Wait for Rancher deployments to be complete, or subsequent steps may fail
 	if err = kubectl.WaitRancher(upstream.Kubeconfig); err != nil {
 		return err
 	}
@@ -542,12 +542,12 @@ func importDownstreamClusterDo(r *dart.Dart, rancherImageTag string, tf *tofu.To
 	}
 
 	if err := kubectl.WaitForReadyCondition(clusters["upstream"].Kubeconfig,
-		"clusters.management.cattle.io", clusterID, "", 10); err != nil {
+		"clusters.management.cattle.io", clusterID, "", "ready", 10); err != nil {
 		errCh <- fmt.Errorf("%s import failed: %w", clusterName, err)
 		return
 	}
 	if err := kubectl.WaitForReadyCondition(clusters["upstream"].Kubeconfig,
-		"cluster.fleet.cattle.io", clusterName, "fleet-default", 10); err != nil {
+		"cluster.fleet.cattle.io", clusterName, "fleet-default", "ready", 10); err != nil {
 		errCh <- fmt.Errorf("%s import failed: %w", clusterName, err)
 		return
 	}


### PR DESCRIPTION
Previous code did not wait after Rancher installation to install Rancher Monitoring.


Since 2.9, some Rancher components need to be ready or the installation will fail, eg.:

```
2024/08/29 14:50:01 chart rancher-monitoring: failed pre-install: warning: Hook pre-install rancher-monitoring/templates/alertmanager/secret.yaml failed: 1 error occurred:
        * Internal error occurred: failed calling webhook "rancher.cattle.io.secrets": failed to call webhook: Post "https://rancher-webhook.cattle-system.svc:443/v1/webhook/mutation/secrets?timeout=15s": no endpoints available fo
r service "rancher-webhook"
```

More components can be added if needed in the same way (eg. `cattle-fleet-system/gitjob` or `cattle-provisioning-capi-system/capi-controller-manager`, which did not pop up in my own tests but might turn out to be relevant).


