### PR TITLE
k6/change_config_maps: fix rate

### DIFF
--- a/k6/k8s.js
+++ b/k6/k8s.js
@@ -28,14 +28,14 @@ export function kubeconfig(file, contextName){
 }
 
 // creates a k8s resource
-export function create(url, body){
+export function create(url, body, retry = true){
     const res = http.post(url, JSON.stringify(body));
 
     check(res, {
         'POST returns status 201 or 409': (r) => r.status === 201 || r.status === 409,
     })
 
-    if (res.status === 409) {
+    if (res.status === 409 && retry) {
         // wait a bit and try again
         sleep(Math.random())
 


### PR DESCRIPTION
Previous code had several issues that resulted in the change rate not being correct:

1. the RATE parameter was not actually read from environment variables 🤦 🤦 🤦 
2. it did not take into account that every k6 iteration we are doing two operations (one creation and one deletion)
3. it did not use the `constant-arrival-rate` executor, which meant the rate was not actually guaranteed by k6 🤦 
4. creation might have caused unintended retries, which would skew the rate

This PR addresses all of the above.