### PR TITLE
rke2: wait until ingress is up

### DIFF
--- a/tofu/modules/rke2/wait_for_k8s.sh
+++ b/tofu/modules/rke2/wait_for_k8s.sh
@@ -9,3 +9,9 @@ do
   echo "Waiting for k8s API to be up..."
   sleep 3
 done
+
+echo "Waiting for the RKE2 ingress controller to be up..."
+kubectl rollout status daemonset \
+  rke2-ingress-nginx-controller \
+  -n kube-system \
+  --timeout 600s


### PR DESCRIPTION
Prevents the following error:

```
* Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": failed to call webhook: Post "https://rke2-ingress-nginx-controller-admission.kube-system.svc:443/networking/v1/ingresses?timeout=10s": no endpoints available for service "rke2-ingress-nginx-controller-admission"
```