### PR TITLE
bugfix: regression in helm install of Rancher monitoring

### DIFF
--- a/cmd/dartboard/subcommands/deploy.go
+++ b/cmd/dartboard/subcommands/deploy.go
@@ -272,7 +272,7 @@ func getRancherMonitoringValsJSON(noSchedToleration bool, mimirURL string) map[s
 	tolerations := []any{}
 	monitoringRestrictions := map[string]any{}
 	if !noSchedToleration {
-		nodeSelector["monitoring"] = true
+		nodeSelector["monitoring"] = "true"
 		tolerations = append(tolerations, map[string]any{"key": "monitoring", "operator": "Exists", "effect": "NoSchedule"})
 		monitoringRestrictions["nodeSelector"] = nodeSelector
 		monitoringRestrictions["tolerations"] = tolerations


### PR DESCRIPTION
This fixes the following error:

```
Release "rancher-monitoring" does not exist. Installing it now. 2024/11/14 13:21:01 chart rancher-monitoring: Error: 5 errors occurred:
        * Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field PodSpec.spec.template.spec.nodeSelector of type string
        * Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field PodSpec.spec.template.spec.nodeSelector of type string
        * Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field PodSpec.spec.template.spec.nodeSelector of type string
        * Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field PodSpec.spec.template.spec.nodeSelector of type string
        * Prometheus.monitoring.coreos.com "rancher-monitoring-prometheus" is invalid: spec.nodeSelector.monitoring: Invalid value: "boolean": spec.nodeSelector.monitoring in body must be of type string: "boolean"
```

this is a regression from #16 