### PR TITLE
add debug log line to run k6 directly

### DIFF
--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/rancher/dartboard/internal/vendored"
 )
 
@@ -152,6 +153,13 @@ func GetStatus(kubepath, kind, name, namespace string) (map[string]any, error) {
 }
 
 func K6run(kubeconfig, name, testPath string, envVars, tags map[string]string, printLogs, record bool) error {
+	// print what we are about to do
+	quotedArgs := []string{"run"}
+	for k, v := range envVars {
+		quotedArgs = append(quotedArgs, "-e", shellescape.Quote(fmt.Sprintf("%s=%s", k, v)))
+	}
+	log.Printf("Running equivalent of: \n.bin/k6 %s\n", strings.Join(quotedArgs, " "))
+
 	// if a kubeconfig is specified, upload it as secret to later mount it
 	if path, ok := envVars["KUBECONFIG"]; ok {
 		err := Exec(kubeconfig, nil, "--namespace="+K6Namespace, "delete", "secret", K6KubeSecretName, "--ignore-not-found")


### PR DESCRIPTION
This makes it easier to debug k6 scripts by outputting in logs the equivalent k6 commandline for a local k6 run.


Currently dartboard runs `k6` from a container in the tester cluster, by first copying over `k6/` and `k6/lib` files as ConfigMaps via `helm`:

```
2024/11/14 15:52:33 Installing chart "tester/k6-files" (charts/k6-files)
2024/11/14 15:52:33 Running command:
.bin/helm --kubeconfig=/Users/SMOIOLI/synced/repos/dartboard/tofu/main/aws/config/tester.yaml upgrade --install --namespace=tester k6-files charts/k6-files --create-namespace
Release "k6-files" does not exist. Installing it now.
NAME: k6-files
LAST DEPLOYED: Thu Nov 14 15:52:36 2024
NAMESPACE: tester
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

And then running `k6` via `kubectl` from a container in a pod in the tester cluster, which requires a rather ugly one-liner JSONPatch blob to mount files in:
```
2024/11/14 15:58:32 Running command:
.bin/kubectl --kubeconfig=/Users/SMOIOLI/synced/repos/dartboard/tofu/main/aws/config/tester.yaml run k6 --image=grafana/k6:0.54.0 --namespace=tester --rm --stdin --restart=Never '--overrides={"apiVersion":"v1","spec":{"containers"
:[{"args":["run","-e","BOOTSTRAP_PASSWORD=admin","-e","BASE_URL=https://ec2-52-90-251-0.compute-1.amazonaws.com:443","-e","PASSWORD=adminadminadmin","-e","IMPORTED_CLUSTER_NAMES=","k6/rancher_setup.js"],"env":[{"name":"K6_PROMETHE
US_RW_SERVER_URL","value":"http://mimir.tester:9009/mimir/api/v1/push"},{"name":"K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM","value":"true"},{"name":"K6_PROMETHEUS_RW_STALE_MARKERS","value":"true"}],"image":"grafana/k6:0.54.0","na
me":"k6","stdin":true,"tty":true,"volumeMounts":[{"mountPath":"/k6","name":"k6-test-files"},{"mountPath":"/k6/lib","name":"k6-lib-files"}],"workingDir":"/"}],"volumes":[{"configMap":{"name":"k6-test-files"},"name":"k6-test-files"}
,{"configMap":{"name":"k6-lib-files"},"name":"k6-lib-files"}]}}'
```

In principle, one can debug `k6` scripts by changing them and then running the two command lines copied from the above logs, ie:

```
.bin/helm --kubeconfig=/Users/SMOIOLI/synced/repos/dartboard/tofu/main/aws/config/tester.yaml upgrade --install --namespace=tester k6-files charts/k6-files --create-namespace

.bin/kubectl --kubeconfig=/Users/SMOIOLI/synced/repos/dartboard/tofu/main/aws/config/tester.yaml run k6 --image=grafana/k6:0.54.0 --namespace=tester --rm --stdin --restart=Never '--overrides={...}"
```

But that is quite cumbersome. This PR adds a log line to produce a simpler copypastable line:

```
2024/11/14 15:58:32 Running equivalent of:

k6 run -e BOOTSTRAP_PASSWORD=admin -e BASE_URL=https://upstream.local.gd:8443 -e PASSWORD=adminadminadmin -e IMPORTED_CLUSTER_NAMES= k6/rancher_setup.js
```

