### PR TITLE
Add debug log line to run k6 directly: refined

### DIFF
--- a/cmd/dartboard/subcommands/deploy.go
+++ b/cmd/dartboard/subcommands/deploy.go
@@ -546,7 +546,7 @@ func importDownstreamClustersRancherSetup(r *dart.Dart, clusters map[string]tofu
 		"IMPORTED_CLUSTER_NAMES": importedClusterNames,
 	}
 
-	if err = kubectl.K6run(tester.Kubeconfig, "rancher-setup", "k6/rancher_setup.js", envVars, nil, true, false); err != nil {
+	if err = kubectl.K6run(tester.Kubeconfig, "k6/rancher_setup.js", envVars, nil, true, upstreamAdd.Local.HTTPSURL, false); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/dartboard/subcommands/load.go
+++ b/cmd/dartboard/subcommands/load.go
@@ -72,7 +72,7 @@ func loadConfigMapAndSecrets(r *dart.Dart, kubecongfig string, clusterName strin
 	secretCount := strconv.Itoa(r.TestVariables.TestSecrets)
 
 	envVars := map[string]string{
-		"BASE_URL":         clusterData.PrivateKubernetesAPIURL,
+		"BASE_URL":         clusterData.KubernetesAddresses.Private,
 		"KUBECONFIG":       clusterData.Kubeconfig,
 		"CONTEXT":          clusterData.Context,
 		"CONFIG_MAP_COUNT": configMapCount,
@@ -86,7 +86,7 @@ func loadConfigMapAndSecrets(r *dart.Dart, kubecongfig string, clusterName strin
 	}
 
 	log.Printf("Load resources on cluster %q (#ConfigMaps: %s, #Secrets: %s)\n", clusterName, configMapCount, secretCount)
-	if err := kubectl.K6run(kubecongfig, "create-k8s-resources", "k6/create_k8s_resources.js", envVars, tags, true, false); err != nil {
+	if err := kubectl.K6run(kubecongfig, "k6/create_k8s_resources.js", envVars, tags, true, clusterData.KubernetesAddresses.Tunnel, false); err != nil {
 		return fmt.Errorf("failed loading ConfigMaps and Secrets on cluster %q: %w", clusterName, err)
 	}
 	return nil
@@ -115,7 +115,7 @@ func loadRolesAndUsers(r *dart.Dart, kubeconfig string, clusterName string, clus
 
 	log.Printf("Load resources on cluster %q (#Roles: %s, #Users: %s)\n", clusterName, roleCount, userCount)
 
-	if err := kubectl.K6run(kubeconfig, "create-roles-users", "k6/create_roles_users.js", envVars, tags, true, false); err != nil {
+	if err := kubectl.K6run(kubeconfig, "k6/create_roles_users.js", envVars, tags, true, clusterAdd.Local.HTTPSURL, false); err != nil {
 		return fmt.Errorf("failed loading Roles and Users on cluster %q: %w", clusterName, err)
 	}
 	return nil
@@ -141,7 +141,7 @@ func loadProjects(r *dart.Dart, kubeconfig string, clusterName string, clusterDa
 
 	log.Printf("Load resources on cluster %q (#Projects: %s)\n", clusterName, projectCount)
 
-	if err := kubectl.K6run(kubeconfig, "create-projects", "k6/create_projects.js", envVars, tags, true, false); err != nil {
+	if err := kubectl.K6run(kubeconfig, "k6/create_projects.js", envVars, tags, true, clusterAdd.Local.HTTPSURL, false); err != nil {
 		return fmt.Errorf("failed loading Projects on cluster %q: %w", clusterName, err)
 	}
 	return nil

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -152,13 +152,17 @@ func GetStatus(kubepath, kind, name, namespace string) (map[string]any, error) {
 	return out, nil
 }
 
-func K6run(kubeconfig, name, testPath string, envVars, tags map[string]string, printLogs, record bool) error {
+func K6run(kubeconfig, testPath string, envVars, tags map[string]string, printLogs bool, localBaseURL string, record bool) error {
 	// print what we are about to do
 	quotedArgs := []string{"run"}
 	for k, v := range envVars {
+		if k == "BASE_URL" {
+			v = localBaseURL
+		}
 		quotedArgs = append(quotedArgs, "-e", shellescape.Quote(fmt.Sprintf("%s=%s", k, v)))
 	}
-	log.Printf("Running equivalent of: \n.bin/k6 %s\n", strings.Join(quotedArgs, " "))
+	quotedArgs = append(quotedArgs, shellescape.Quote(testPath))
+	log.Printf("Running equivalent of:\nk6 %s\n", strings.Join(quotedArgs, " "))
 
 	// if a kubeconfig is specified, upload it as secret to later mount it
 	if path, ok := envVars["KUBECONFIG"]; ok {

--- a/internal/tofu/tofu.go
+++ b/internal/tofu/tofu.go
@@ -44,13 +44,19 @@ type ClusterAppAddresses struct {
 	Tunnel  ClusterAddress `json:"tunnel"`
 }
 
+type Addresses struct {
+	Public  string `json:"public"`
+	Private string `json:"private"`
+	Tunnel  string `json:"tunnel"`
+}
+
 type Cluster struct {
-	AppAddresses            ClusterAppAddresses `json:"app_addresses"`
-	Context                 string              `json:"context"`
-	IngressClassName        string              `json:"ingress_class_name"`
-	Kubeconfig              string              `json:"kubeconfig"`
-	NodeAccessCommands      map[string]string   `json:"node_access_commands"`
-	PrivateKubernetesAPIURL string              `json:"private_kubernetes_api_url"`
+	AppAddresses        ClusterAppAddresses `json:"app_addresses"`
+	Context             string              `json:"context"`
+	IngressClassName    string              `json:"ingress_class_name"`
+	Kubeconfig          string              `json:"kubeconfig"`
+	NodeAccessCommands  map[string]string   `json:"node_access_commands"`
+	KubernetesAddresses Addresses           `json:"kubernetes_addresses"`
 }
 
 type Clusters struct {

--- a/tofu/main/aws/outputs.tf
+++ b/tofu/main/aws/outputs.tf
@@ -3,8 +3,15 @@ locals {
     kubeconfig = module.k3s_cluster[i].kubeconfig
     context    = module.k3s_cluster[i].context
 
-    // alternative URL to reach the API from the same network this cluster is in
-    private_kubernetes_api_url = "https://${module.k3s_cluster[i].first_server_private_name}:6443"
+    // addresses of the Kubernetes API server
+    kubernetes_addresses = {
+      // resolvable over the Internet
+      public = "https://${module.k3s_cluster[i].first_server_public_name}:6443"
+      // resolvable from the network this cluster runs in
+      private = "https://${module.k3s_cluster[i].first_server_private_name}:6443"
+      // resolvable from the host running OpenTofu
+      tunnel = module.k3s_cluster[i].local_kubernetes_api_url
+    }
 
     // addresses of applications running in this cluster
     app_addresses = {
@@ -33,8 +40,15 @@ locals {
     kubeconfig = module.rke2_cluster[i].kubeconfig
     context    = module.rke2_cluster[i].context
 
-    // alternative URL to reach the API from the same network this cluster is in
-    private_kubernetes_api_url = "https://${module.rke2_cluster[i].first_server_private_name}:6443"
+    // addresses of the Kubernetes API server
+    kubernetes_addresses = {
+      // resolvable over the Internet
+      public = "https://${module.rke2_cluster[i].first_server_public_name}:6443"
+      // resolvable from the network this cluster runs in
+      private = "https://${module.rke2_cluster[i].first_server_private_name}:6443"
+      // resolvable from the host running OpenTofu
+      tunnel = module.rke2_cluster[i].local_kubernetes_api_url
+    }
 
     // addresses of applications running in this cluster
     app_addresses = {

--- a/tofu/main/azure/outputs.tf
+++ b/tofu/main/azure/outputs.tf
@@ -3,8 +3,15 @@ locals {
     kubeconfig = module.k3s_cluster[i].kubeconfig
     context    = module.k3s_cluster[i].context
 
-    // alternative URL to reach the API from the same network this cluster is in
-    private_kubernetes_api_url = "https://${module.k3s_cluster[i].first_server_private_name}:6443"
+    // addresses of the Kubernetes API server
+    kubernetes_addresses = {
+      // resolvable over the Internet
+      public = "https://${module.k3s_cluster[i].first_server_public_name}:6443"
+      // resolvable from the network this cluster runs in
+      private = "https://${module.k3s_cluster[i].first_server_private_name}:6443"
+      // resolvable from the host running OpenTofu
+      tunnel = module.k3s_cluster[i].local_kubernetes_api_url
+    }
 
     // addresses of applications running in this cluster
     app_addresses = {
@@ -33,8 +40,15 @@ locals {
     kubeconfig = module.rke2_cluster[i].kubeconfig
     context    = module.rke2_cluster[i].context
 
-    // alternative URL to reach the API from the same network this cluster is in
-    private_kubernetes_api_url = "https://${module.rke2_cluster[i].first_server_private_name}:6443"
+    // addresses of the Kubernetes API server
+    kubernetes_addresses = {
+      // resolvable over the Internet
+      public = "https://${module.rke2_cluster[i].first_server_public_name}:6443"
+      // resolvable from the network this cluster runs in
+      private = "https://${module.rke2_cluster[i].first_server_private_name}:6443"
+      // resolvable from the host running OpenTofu
+      tunnel = module.rke2_cluster[i].local_kubernetes_api_url
+    }
 
     // addresses of applications running in this cluster
     app_addresses = {
@@ -63,8 +77,15 @@ locals {
     kubeconfig = module.aks_cluster[i].kubeconfig
     context    = module.aks_cluster[i].context
 
-    // same as the kubeconfig URL
-    private_kubernetes_api_url = "https://${module.aks_cluster[i].cluster_public_name}:443"
+    // addresses of the Kubernetes API server
+    kubernetes_addresses = {
+      // resolvable over the Internet
+      public = "https://${module.aks_cluster[i].cluster_public_name}:443"
+      // resolvable from the network this cluster runs in
+      private = "https://${module.aks_cluster[i].cluster_public_name}:443"
+      // resolvable from the host running OpenTofu
+      tunnel = "https://${module.aks_cluster[i].cluster_public_name}:443"
+    }
 
     // addresses of applications running in this cluster
     app_addresses = {

--- a/tofu/main/k3d/outputs.tf
+++ b/tofu/main/k3d/outputs.tf
@@ -4,8 +4,15 @@ output "clusters" {
       kubeconfig = module.cluster[i].kubeconfig
       context    = module.cluster[i].context
 
-      // alternative URL to reach the API from the same network this cluster is in
-      private_kubernetes_api_url = "https://${module.cluster[i].first_server_private_name}:6443"
+      // addresses of the Kubernetes API server
+      kubernetes_addresses = {
+        // resolvable over the Internet
+        public = null
+        // resolvable from the network this cluster runs in
+        private = "https://${module.cluster[i].first_server_private_name}:6443"
+        // resolvable from the host running OpenTofu
+        tunnel = module.cluster[i].local_kubernetes_api_url
+      }
 
       // addresses of applications running in this cluster
       app_addresses = {

--- a/tofu/main/openstack/outputs.tf
+++ b/tofu/main/openstack/outputs.tf
@@ -4,8 +4,15 @@ output "clusters" {
       kubeconfig = module.cluster[i].kubeconfig
       context    = module.cluster[i].context
 
-      // alternative URL to reach the API from the same network this cluster is in
-      private_kubernetes_api_url = "https://${module.cluster[i].first_server_private_name}:6443"
+      // addresses of the Kubernetes API server
+      kubernetes_addresses = {
+        // resolvable over the Internet
+        public = "https://${module.cluster[i].first_server_public_name}:6443"
+        // resolvable from the network this cluster runs in
+        private = "https://${module.cluster[i].first_server_private_name}:6443"
+        // resolvable from the host running OpenTofu
+        tunnel = module.cluster[i].local_kubernetes_api_url
+      }
 
       // addresses of applications running in this cluster
       app_addresses = {

--- a/tofu/main/ssh/outputs.tf
+++ b/tofu/main/ssh/outputs.tf
@@ -4,8 +4,15 @@ output "clusters" {
       kubeconfig = module.cluster[i].kubeconfig
       context    = module.cluster[i].context
 
-      // alternative URL to reach the API from the same network this cluster is in
-      private_kubernetes_api_url = "https://${module.cluster[i].first_server_private_name}:6443"
+      // addresses of the Kubernetes API server
+      kubernetes_addresses = {
+        // resolvable over the Internet
+        public = "https://${module.cluster[i].first_server_public_name}:6443"
+        // resolvable from the network this cluster runs in
+        private = "https://${module.cluster[i].first_server_private_name}:6443"
+        // resolvable from the host running OpenTofu
+        tunnel = module.cluster[i].local_kubernetes_api_url
+      }
 
       // addresses of applications running in this cluster
       app_addresses = {

--- a/tofu/modules/aws_k3s/outputs.tf
+++ b/tofu/modules/aws_k3s/outputs.tf
@@ -10,6 +10,10 @@ output "kubeconfig" {
   value = module.k3s.kubeconfig
 }
 
+output "local_kubernetes_api_url" {
+  value = module.k3s.local_kubernetes_api_url
+}
+
 output "context" {
   value = module.k3s.context
 }

--- a/tofu/modules/aws_rke2/outputs.tf
+++ b/tofu/modules/aws_rke2/outputs.tf
@@ -10,6 +10,10 @@ output "kubeconfig" {
   value = module.rke2.kubeconfig
 }
 
+output "local_kubernetes_api_url" {
+  value = module.rke2.local_kubernetes_api_url
+}
+
 output "context" {
   value = module.rke2.context
 }

--- a/tofu/modules/azure_aks/output.tf
+++ b/tofu/modules/azure_aks/output.tf
@@ -1,5 +1,11 @@
+// note: hosts in this file need to be resolvable from the host running OpenTofu
 output "kubeconfig" {
   value = abspath(local_file.kubeconfig.filename)
+}
+
+// note: must match the host in kubeconfig
+output "local_kubernetes_api_url" {
+  value = "https://${azurerm_kubernetes_cluster.cluster.kube_config.host}:6443"
 }
 
 output "context" {

--- a/tofu/modules/azure_k3s/output.tf
+++ b/tofu/modules/azure_k3s/output.tf
@@ -10,6 +10,10 @@ output "kubeconfig" {
   value = module.k3s.kubeconfig
 }
 
+output "local_kubernetes_api_url" {
+  value = module.k3s.local_kubernetes_api_url
+}
+
 output "context" {
   value = module.k3s.context
 }

--- a/tofu/modules/azure_rke2/output.tf
+++ b/tofu/modules/azure_rke2/output.tf
@@ -10,6 +10,10 @@ output "kubeconfig" {
   value = module.rke2.kubeconfig
 }
 
+output "local_kubernetes_api_url" {
+  value = module.rke2.local_kubernetes_api_url
+}
+
 output "context" {
   value = module.rke2.context
 }

--- a/tofu/modules/openstack_k3s/outputs.tf
+++ b/tofu/modules/openstack_k3s/outputs.tf
@@ -10,6 +10,10 @@ output "kubeconfig" {
   value = module.k3s.kubeconfig
 }
 
+output "local_kubernetes_api_url" {
+  value = module.k3s.local_kubernetes_api_url
+}
+
 output "context" {
   value = module.k3s.context
 }

--- a/tofu/modules/ssh_k3s/outputs.tf
+++ b/tofu/modules/ssh_k3s/outputs.tf
@@ -6,6 +6,10 @@ output "kubeconfig" {
   value = module.k3s.kubeconfig
 }
 
+output "local_kubernetes_api_url" {
+  value = module.k3s.local_kubernetes_api_url
+}
+
 output "context" {
   value = module.k3s.context
 }


### PR DESCRIPTION
This builds on top of #26 to make it more useful.

Specifically, it substitutes k6's `-e BASE_URL=...` parameter with the "correct" base url for k6 to connect to, which is not trivial because depending on the situation and the backend it might mean:
 - the Rancher address - possibly an alias if a tunnel is used (instead of the private one) or a public one
 - the Kubernetes address - possibly an alias if the tunnel is used (instead of the private one) or a public one

In order to use the right address, I had to expand a bit the format of tofu module outputs to clarify which-is-which among Rancher/Kubernetes/public/private/tunnelled addresses. Hence this patch is way bigger than it should be.

Nevertheless I tested it locally and it seems to work well in the various cases.

I am open to fix up the harvester module if this PR is accepted, of course.