### PR TITLE
Unbreak AWS cluster naming

### DIFF
--- a/darts/aws_full.yaml
+++ b/darts/aws_full.yaml
@@ -18,7 +18,6 @@ tofu_variables:
 #  bastion_host_ami: ami-0e55a8b472a265e3f # openSUSE-Leap-15-5-v20230608-hvm-ssd-arm64
 
 #  upstream_cluster:
-#    name_prefix: upstream
 #    server_count: 1
 #    agent_count: 0
 #    distro_version: v1.26.9+k3s1
@@ -31,7 +30,6 @@ tofu_variables:
 
 #  deploy_tester_cluster: true
 #  tester_cluster:
-#    name_prefix: tester
 #    server_count: 1
 #    agent_count: 0
 #    distro_version: v1.26.9+k3s1
@@ -44,7 +42,6 @@ tofu_variables:
 
 #  downstream_cluster_templates:
 #    - cluster_count: 0
-#      name_prefix: downstream
 #      server_count: 1
 #      agent_count: 0
 #      distro_version: v1.26.9+k3s1

--- a/tofu/main/aws/locals.tf
+++ b/tofu/main/aws/locals.tf
@@ -1,14 +1,17 @@
 locals {
-  downstream_clusters = flatten([
+  unnamed_downstream_clusters = flatten([
     for i, template in var.downstream_cluster_templates : [
-      for j in range(template.cluster_count) : merge(template, { name = "${template.name_prefix}${i}-${j}" })
+      for j in range(template.cluster_count) : template
   ] if template.cluster_count > 0 ])
-  all_clusters = flatten(concat([var.upstream_cluster],
+
+  downstream_clusters = [for i, cluster in local.unnamed_downstream_clusters : merge(cluster, {name = "downstream-${i}"})]
+
+  all_clusters = flatten(concat(
+    [merge(var.upstream_cluster, {name = "upstream"})],
     local.downstream_clusters,
-    var.deploy_tester_cluster ? [var.tester_cluster] : []
+    var.deploy_tester_cluster ? [[merge(var.tester_cluster, {name = "tester"})]] : []
   ))
 
-
-  k3s_clusters  = [for i, cluster in local.all_clusters : merge(cluster, {name = "${cluster.name_prefix}-${i}"}) if strcontains(cluster.distro_version, "k3s")]
-  rke2_clusters = [for i, cluster in local.all_clusters : merge(cluster, {name = "${cluster.name_prefix}-${i}"}) if strcontains(cluster.distro_version, "rke2")]
+  k3s_clusters  = [for i, cluster in local.all_clusters : cluster if strcontains(cluster.distro_version, "k3s")]
+  rke2_clusters = [for i, cluster in local.all_clusters : cluster if strcontains(cluster.distro_version, "rke2")]
 }

--- a/tofu/main/aws/variables.tf
+++ b/tofu/main/aws/variables.tf
@@ -44,7 +44,6 @@ variable "ssh_bastion_user" {
 # Upstream cluster specifics
 variable "upstream_cluster" {
   type = object({
-    name_prefix    = string // Prefix to append to objects created for this cluster
     server_count   = number // Number of server nodes in the upstream cluster
     agent_count    = number // Number of agent nodes in the upstream cluster
     distro_version = string // Version of the Kubernetes distro in the upstream cluster
@@ -59,7 +58,6 @@ variable "upstream_cluster" {
     ami           = string // AMI for upstream cluster nodes
   })
   default = {
-    name_prefix    = "upstream"
     server_count   = 1
     agent_count    = 0
     distro_version = "v1.26.9+k3s1"
@@ -80,7 +78,6 @@ variable "upstream_cluster" {
 variable "downstream_cluster_templates" {
   type = list(object({
     cluster_count       = number // Number of downstream clusters that should be created using this configuration
-    name_prefix    = string // Prefix to append to objects created for this cluster
     server_count   = number // Number of server nodes in the downstream cluster
     agent_count    = number // Number of agent nodes in the downstream cluster
     distro_version = string // Version of the Kubernetes distro in the downstream cluster
@@ -96,7 +93,6 @@ variable "downstream_cluster_templates" {
   }))
   default = [{
     cluster_count       = 0 // defaults to 0 to keep in-line with previous behavior
-    name_prefix    = "downstream"
     server_count   = 1
     agent_count    = 0
     distro_version = "v1.26.9+k3s1"
@@ -116,7 +112,6 @@ variable "downstream_cluster_templates" {
 # Tester cluster specifics
 variable "tester_cluster" {
   type = object({
-    name_prefix    = string // Prefix to append to objects created for this cluster
     server_count   = number // Number of server nodes in the tester cluster
     agent_count    = number // Number of agent nodes in the tester cluster
     distro_version = string // Version of the Kubernetes distro in the tester cluster
@@ -131,7 +126,6 @@ variable "tester_cluster" {
     ami           = string // AMI for tester cluster nodes
   })
   default = {
-    name_prefix    = "tester"
     server_count   = 1
     agent_count    = 0
     distro_version = "v1.26.9+k3s1"


### PR DESCRIPTION
The AWS backend got inadvertently broken by #19 

go code expects specific cluster names: upstream, tester, and downstream + a suffix

Current AWS code returns names like upstream-0 or tester-1 which result in dartboard deploy failing.

This PR removes the ability to set a prefix and adds suffix numbers only to downstream to keep the contract with the go part of the code.

Tested manually on AWS.