### PR TITLE
bugfix: set monitoring taints correctly

### DIFF
--- a/internal/tofu/tofu.go
+++ b/internal/tofu/tofu.go
@@ -51,12 +51,13 @@ type Addresses struct {
 }
 
 type Cluster struct {
-	AppAddresses        ClusterAppAddresses `json:"app_addresses"`
-	Context             string              `json:"context"`
-	IngressClassName    string              `json:"ingress_class_name"`
-	Kubeconfig          string              `json:"kubeconfig"`
-	NodeAccessCommands  map[string]string   `json:"node_access_commands"`
-	KubernetesAddresses Addresses           `json:"kubernetes_addresses"`
+	AppAddresses             ClusterAppAddresses `json:"app_addresses"`
+	Context                  string              `json:"context"`
+	IngressClassName         string              `json:"ingress_class_name"`
+	Kubeconfig               string              `json:"kubeconfig"`
+	NodeAccessCommands       map[string]string   `json:"node_access_commands"`
+	KubernetesAddresses      Addresses           `json:"kubernetes_addresses"`
+	ReserveNodeForMonitoring bool                `json:"reserve_node_for_monitoring"`
 }
 
 type Clusters struct {

--- a/tofu/main/aws/outputs.tf
+++ b/tofu/main/aws/outputs.tf
@@ -34,6 +34,7 @@ locals {
 
     node_access_commands = module.k3s_cluster[i].node_access_commands
     ingress_class_name   = module.k3s_cluster[i].ingress_class_name
+    reserve_node_for_monitoring = cluster.reserve_node_for_monitoring
     }
   }
   rke2_outputs = { for i, cluster in local.rke2_clusters : cluster.name => {
@@ -71,6 +72,7 @@ locals {
 
     node_access_commands = module.rke2_cluster[i].node_access_commands
     ingress_class_name   = module.rke2_cluster[i].ingress_class_name
+    reserve_node_for_monitoring = cluster.reserve_node_for_monitoring
     }
   }
 }

--- a/tofu/main/azure/outputs.tf
+++ b/tofu/main/azure/outputs.tf
@@ -34,6 +34,7 @@ locals {
 
     node_access_commands = module.k3s_cluster[i].node_access_commands
     ingress_class_name   = module.k3s_cluster[i].ingress_class_name
+    reserve_node_for_monitoring = cluster.reserve_node_for_monitoring
     }
   }
   rke2_outputs = { for i, cluster in local.rke2_clusters : cluster.name => {
@@ -71,6 +72,7 @@ locals {
 
     node_access_commands = module.rke2_cluster[i].node_access_commands
     ingress_class_name   = module.rke2_cluster[i].ingress_class_name
+    reserve_node_for_monitoring = cluster.reserve_node_for_monitoring
     }
   }
   aks_outputs = { for i, cluster in local.aks_clusters : cluster.name => {
@@ -108,6 +110,7 @@ locals {
 
     node_access_commands = module.aks_cluster[i].node_access_commands
     ingress_class_name   = module.aks_cluster[i].ingress_class_name
+    reserve_node_for_monitoring = cluster.reserve_node_for_monitoring
     }
   }
 }

--- a/tofu/main/k3d/outputs.tf
+++ b/tofu/main/k3d/outputs.tf
@@ -35,6 +35,7 @@ output "clusters" {
 
       node_access_commands = {}
       ingress_class_name   = null
+      reserve_node_for_monitoring = cluster.reserve_node_for_monitoring
     }
   }
 }

--- a/tofu/main/openstack/outputs.tf
+++ b/tofu/main/openstack/outputs.tf
@@ -35,6 +35,7 @@ output "clusters" {
 
       node_access_commands = module.cluster[i].node_access_commands
       ingress_class_name   = module.cluster[i].ingress_class_name
+      reserve_node_for_monitoring = cluster.reserve_node_for_monitoring
     }
   }
 }

--- a/tofu/main/ssh/outputs.tf
+++ b/tofu/main/ssh/outputs.tf
@@ -35,6 +35,7 @@ output "clusters" {
 
       node_access_commands = module.cluster[i].node_access_commands
       ingress_class_name   = module.cluster[i].ingress_class_name
+      reserve_node_for_monitoring = cluster.reserve_node_for_monitoring
     }
   }
 }


### PR DESCRIPTION
dartboard offers an option to set "monitoring" taints and node selectors to force all monitoring workloads to a specific node.

Tofu code made this parametric for each cluster at some point, while Go code stuck with an earlier assumption where all k3d clusters did not use this, and all others did.


This patch corrects that outdated assumption and makes go code follow Tofu parameters.