### PR TITLE
Bugfix: wait for webhook to be ready downstream as well

### DIFF
--- a/cmd/dartboard/subcommands/deploy.go
+++ b/cmd/dartboard/subcommands/deploy.go
@@ -514,6 +514,12 @@ func importDownstreamClusterDo(r *dart.Dart, rancherImageTag string, tf *tofu.To
 		errCh <- fmt.Errorf("%s import failed: %w", clusterName, err)
 		return
 	}
+
+	err = kubectl.WaitForReadyCondition(downstream.Kubeconfig, "deployment", "rancher-webhook", "cattle-system", "available", 60)
+	if err != nil {
+		errCh <- fmt.Errorf("%s waiting for rancher-webhook failed: %w", clusterName, err)
+		return
+	}
 	if r.ChartVariables.DownstreamRancherMonitoring {
 		if err := chartInstallRancherMonitoring(r, &downstream); err != nil {
 			errCh <- fmt.Errorf("downstream monitoring installation on cluster %s failed: %w", clusterName, err)


### PR DESCRIPTION
Adds an extra waiting step to rancher-webhook downstream.

In some situations (tested k3d locally) the rancher-monitoring chart is installed earlier than cluster import is completed, and the webhook fails because its endpoint is not yet ready.