### PR TITLE
Add support for specifying arbitrary helm values for installing Rancher

### DIFF
--- a/cmd/dartboard/subcommands/deploy.go
+++ b/cmd/dartboard/subcommands/deploy.go
@@ -191,8 +191,8 @@ func chartInstallRancher(r *dart.Dart, rancherImageTag string, cluster *tofu.Clu
 	chartVals := getRancherValsJSON(r.ChartVariables.RancherImageOverride, rancherImageTag, r.ChartVariables.AdminPassword, rancherClusterName, rancherClusterURL, r.ChartVariables.RancherReplicas)
 
 	var extraArgs []string
-	if r.ChartVariables.Values != "" {
-		p, err := writeValuesFile(r.ChartVariables.Values)
+	if r.ChartVariables.RancherValues != "" {
+		p, err := writeValuesFile(r.ChartVariables.RancherValues)
 		if err != nil {
 			return fmt.Errorf("writing extra values file: %w", err)
 		}

--- a/darts/aws.yaml
+++ b/darts/aws.yaml
@@ -77,6 +77,10 @@ chart_variables:
 #  rancher_image_override: rancher/rancher
 #  rancher_image_tag_override: v2.8.6-debug-1
 
+# Set arbitrary helm values (in yaml format) for installing Rancher
+#  values: |
+#    features: "my-feature-flag=true"
+
 test_variables:
   test_config_maps: 2000
   test_secrets: 2000

--- a/darts/aws.yaml
+++ b/darts/aws.yaml
@@ -78,7 +78,7 @@ chart_variables:
 #  rancher_image_tag_override: v2.8.6-debug-1
 
 # Set arbitrary helm values (in yaml format) for installing Rancher
-#  values: |
+#  rancher_values: |
 #    features: "my-feature-flag=true"
 
 test_variables:

--- a/darts/azure.yaml
+++ b/darts/azure.yaml
@@ -103,6 +103,10 @@ chart_variables:
 #  rancher_image_override: rancher/rancher
 #  rancher_image_tag_override: v2.8.6-debug-1
 
+# Set arbitrary helm values (in yaml format) for installing Rancher
+#  values: |
+#    features: "my-feature-flag=true"
+
 test_variables:
   test_config_maps: 2000
   test_secrets: 2000

--- a/darts/azure.yaml
+++ b/darts/azure.yaml
@@ -104,7 +104,7 @@ chart_variables:
 #  rancher_image_tag_override: v2.8.6-debug-1
 
 # Set arbitrary helm values (in yaml format) for installing Rancher
-#  values: |
+#  rancher_values: |
 #    features: "my-feature-flag=true"
 
 test_variables:

--- a/darts/k3d.yaml
+++ b/darts/k3d.yaml
@@ -60,7 +60,7 @@ chart_variables:
 #  rancher_image_tag_override: v2.8.6-debug-1
 
 # Set arbitrary helm values (in yaml format) for installing Rancher
-#  values: |
+#  rancher_values: |
 #    features: "my-feature-flag=true"
 
 

--- a/darts/k3d.yaml
+++ b/darts/k3d.yaml
@@ -59,6 +59,11 @@ chart_variables:
 #  rancher_image_override: rancher/rancher
 #  rancher_image_tag_override: v2.8.6-debug-1
 
+# Set arbitrary helm values (in yaml format) for installing Rancher
+#  values: |
+#    features: "my-feature-flag=true"
+
+
 test_variables:
   test_config_maps: 2000
   test_secrets: 2000

--- a/internal/dart/recipe.go
+++ b/internal/dart/recipe.go
@@ -32,7 +32,7 @@ type ChartVariables struct {
 	RancherMonitoringVersion    string `yaml:"rancher_monitoring_version"`
 	CertManagerVersion          string `yaml:"cert_manager_version"`
 	TesterGrafanaVersion        string `yaml:"tester_grafana_version"`
-	Values                      string `yaml:"values"`
+	RancherValues               string `yaml:"rancher_values"`
 }
 
 type TestVariables struct {

--- a/internal/dart/recipe.go
+++ b/internal/dart/recipe.go
@@ -32,6 +32,7 @@ type ChartVariables struct {
 	RancherMonitoringVersion    string `yaml:"rancher_monitoring_version"`
 	CertManagerVersion          string `yaml:"cert_manager_version"`
 	TesterGrafanaVersion        string `yaml:"tester_grafana_version"`
+	Values                      string `yaml:"values"`
 }
 
 type TestVariables struct {

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -25,7 +25,7 @@ import (
 	"github.com/rancher/dartboard/internal/vendored"
 )
 
-func Install(kubecfg, chartLocation, releaseName, namespace string, vals map[string]any) error {
+func Install(kubecfg, chartLocation, releaseName, namespace string, vals map[string]any, extraArgs ...string) error {
 	args := []string{
 		"--kubeconfig=" + kubecfg,
 		"upgrade",
@@ -46,6 +46,7 @@ func Install(kubecfg, chartLocation, releaseName, namespace string, vals map[str
 		}
 		args = append(args, "--set-json="+valueString)
 	}
+	args = append(args, extraArgs...)
 
 	cmd := vendored.Command("helm", args...)
 	var errStream strings.Builder


### PR DESCRIPTION
By setting a yaml-formatted text at `chart_variables.rancher_values` inside a Dartfile.