### PR TITLE
Use correct cluster name when importing images into k3d

### DIFF
--- a/cmd/dartboard/subcommands/utils.go
+++ b/cmd/dartboard/subcommands/utils.go
@@ -162,8 +162,7 @@ func importImageIntoK3d(tf *tofu.Tofu, image string, cluster tofu.Cluster) error
 		}
 
 		if len(images) > 0 {
-			err = k3d.ImageImport(cluster, images[0])
-			if err != nil {
+			if err := k3d.ImageImport(cluster.Name, images[0]); err != nil {
 				return err
 			}
 		}

--- a/internal/k3d/k3d.go
+++ b/internal/k3d/k3d.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/rancher/dartboard/internal/tofu"
 	"github.com/rancher/dartboard/internal/vendored"
 )
 
-func ImageImport(cluster tofu.Cluster, image string) error {
-	args := []string{"image", "import", "--cluster", strings.Replace(cluster.Context, "k3d-", "", -1), image}
+func ImageImport(k3dClusterName string, image string) error {
+	args := []string{"image", "import", "--cluster", k3dClusterName, image}
 
 	cmd := vendored.Command("k3d", args...)
 	var errStream strings.Builder

--- a/internal/tofu/tofu.go
+++ b/internal/tofu/tofu.go
@@ -52,6 +52,7 @@ type Addresses struct {
 
 type Cluster struct {
 	AppAddresses             ClusterAppAddresses `json:"app_addresses"`
+	Name                     string              `json:"name"`
 	Context                  string              `json:"context"`
 	IngressClassName         string              `json:"ingress_class_name"`
 	Kubeconfig               string              `json:"kubeconfig"`

--- a/tofu/modules/k3d/k3s/main.tf
+++ b/tofu/modules/k3d/k3s/main.tf
@@ -325,6 +325,7 @@ resource "k3d_cluster" "cluster" {
 
 locals {
   local_kubernetes_api_url = nonsensitive(k3d_cluster.cluster[0].credentials[0].host)
+  k3d_cluster_name = "${var.project_name}-${var.name}"
 }
 
 resource "local_file" "kubeconfig" {
@@ -337,19 +338,19 @@ resource "local_file" "kubeconfig" {
           certificate-authority-data = base64encode(k3d_cluster.cluster[0].credentials[0].cluster_ca_certificate)
           server                     = local.local_kubernetes_api_url
         }
-        name = "k3d-${var.project_name}-${var.name}"
+        name = "k3d-${local.k3d_cluster_name}"
       }
     ]
     contexts = [
       {
         context = {
-          cluster = "k3d-${var.project_name}-${var.name}"
-          user : "admin@k3d-${var.project_name}-${var.name}"
+          cluster = "k3d-${local.k3d_cluster_name}"
+          user : "admin@k3d-${local.k3d_cluster_name}"
         }
-        name = "k3d-${var.project_name}-${var.name}"
+        name = "k3d-${local.k3d_cluster_name}"
       }
     ]
-    current-context = "k3d-${var.project_name}-${var.name}"
+    current-context = "k3d-${local.k3d_cluster_name}"
     kind            = "Config"
     preferences     = {}
     users = [
@@ -358,7 +359,7 @@ resource "local_file" "kubeconfig" {
           client-certificate-data : base64encode(k3d_cluster.cluster[0].credentials[0].client_certificate)
           client-key-data : base64encode(k3d_cluster.cluster[0].credentials[0].client_key)
         }
-        name : "admin@k3d-${var.project_name}-${var.name}"
+        name : "admin@k3d-${local.k3d_cluster_name}"
       }
     ]
   })

--- a/tofu/modules/k3d/k3s/outputs.tf
+++ b/tofu/modules/k3d/k3s/outputs.tf
@@ -2,6 +2,7 @@ output "config" {
   value = {
     kubeconfig = var.server_count > 0 ? abspath(local_file.kubeconfig[0].filename) : null
     context    = var.name
+    name       = local.k3d_cluster_name
 
     // addresses of the Kubernetes API server
     kubernetes_addresses = {


### PR DESCRIPTION
Setting `chart_variables.rancher_image_tag_override` fails during import with the following error:
```
2025/01/21 15:55:03 Exec: docker images --filter=reference=rancher/rancher:v2.11-dev --format=json
2025/01/21 15:55:03 Running command:
.bin/k3d image import --cluster upstream rancher/rancher:v2.11-dev
2025/01/21 15:55:04 FATA[0000] failed to get cluster upstream: No nodes found for given cluster
```
The problem resides in the `--cluster=upstream` parameter, which is taken from the `tofu.Cluster`'s `context` property, which differs from the k3d cluster name ("`st-upstream`")