### PR TITLE
Upgrade terraform-provider-k3d to support newer versions of k3s

### DIFF
--- a/tofu/main/k3d/terraform.tf
+++ b/tofu/main/k3d/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     }
     k3d = {
       source  = "moio/k3d"
-      version = "0.0.10"
+      version = "0.0.11"
     }
   }
 }


### PR DESCRIPTION
After [upgrading the k3d dependency](https://github.com/moio/terraform-provider-k3d/pull/1), the newer version of k3d [brings support for recent k3s versions](https://github.com/k3d-io/k3d/pull/1479).