### PR TITLE
Fix networking problems after upgrading K3D

### DIFF
--- a/tofu/main/k3d/main.tf
+++ b/tofu/main/k3d/main.tf
@@ -1,3 +1,9 @@
+provider "k3d" {
+  fixes = {
+      "dns" = false
+  }
+}
+
 module "network" {
   source       = "../../modules/k3d/network"
   project_name = var.project_name

--- a/tofu/main/k3d/terraform.tf
+++ b/tofu/main/k3d/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     }
     k3d = {
       source  = "moio/k3d"
-      version = "0.0.11"
+      version = "0.0.12"
     }
   }
 }


### PR DESCRIPTION
The new version of (see #40) seems to include a new "fix" for configuring DNS, that breaks the setup in my environment. https://github.com/k3d-io/k3d/pull/1492 disables that behavior for `host` network modes, which is not the case for dartboard, as it creates a dedicated network.
