### PR TITLE
Added import metrics script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ tofu/main/*/*config
 
 # Others
 scripts/utils/*.txt
+scripts/utils/metrics*
+scripts/utils/chunks_head
+scripts/utils/wal
+scripts/utils/queries.active
+scripts/utils/*.tar.gz
 
 # Binaries
 /dartboard

--- a/scripts/utils/import-metrics-loop.sh
+++ b/scripts/utils/import-metrics-loop.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# set kubeconfig
+export KUBECONFIG=$1
+
+# set timestamp, create dir for export path, set permissions, navigate
+st1=$(date +"%Y-%m-%d")
+mkdir -p $PWD/metrics-$st1
+chmod +x metrics-$st1
+cd metrics-$st1
+
+selector='{__name__!=""}' 
+
+
+# run script for mimirtool via kubectl on target cluster
+bash -c "./../import-metrics-mimirtool.sh $1" &
+
+#TODO: improve wait
+sleep 5
+
+
+for i in 6 4 2
+do
+
+j=$((${i}-2))
+
+
+from="$(date -u -v-${i}H +"%Y-%m-%dT%H:%M:00Z")"
+to="$(date -u -v-${j}H +"%Y-%m-%dT%H:%M:00Z")"
+
+# from separate mimirtool shell execute remote read
+kubectl exec -n cattle-monitoring-system mimirtool --insecure-skip-tls-verify -i -t -- mimirtool remote-read export --tsdb-path ./prometheus-export --address http://rancher-monitoring-prometheus:9090 --remote-read-path /api/v1/read --to=$to --from=$from --selector $selector
+
+# compress metrics data from export
+kubectl exec -n cattle-monitoring-system mimirtool --insecure-skip-tls-verify -i -t -- tar zcf /tmp/prometheus-export.tar.gz ./prometheus-export
+
+# set filename timestamp
+st2=$(date +"%Y-%m-%d--%H-%M-%S")
+
+# copy exported metrics data to timestamped tarball
+kubectl -n cattle-monitoring-system cp mimirtool:/tmp/prometheus-export.tar.gz ./prometheus-export-$st2.tar.gz
+
+# clear export data from pod, 
+#kubectl exec -n cattle-monitoring-system mimirtool --insecure-skip-tls-verify -i -t -- rm -rf prometheus-export
+
+# unpack, navigate
+tar xf prometheus-export-$st2.tar.gz
+cd prometheus-export
+
+# aggregate tsdb
+cp -R `ls | grep -v "wal"` ../
+
+# cleanup
+cd ../
+rm -rf prometheus-export
+
+sleep 5
+
+
+done
+
+# kill mimirtool pod
+kubectl delete pod -n cattle-monitoring-system mimirtool
+
+# run prometheus graph on metrics data (locally via docker), overlapping/obsolete blocks are deleted during compaction
+docker run --rm -u "$(id -u)" -ti -p 9090:9090 -v $PWD:/prometheus rancher/mirrored-prometheus-prometheus:v2.42.0 --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=1y --config.file=/dev/null
+

--- a/scripts/utils/import-metrics-mimirtool.sh
+++ b/scripts/utils/import-metrics-mimirtool.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# set kubeconfig
+export KUBECONFIG=$1
+
+# run mimirtool, keep shell open
+screen -t -s -d -m bash -c "kubectl -n cattle-monitoring-system run mimirtool --rm -ti --image=grafana/mimirtool:2.13.0 --env config.expand-env=true --env querier.max-samples=100000000 --command -- sh" &

--- a/scripts/utils/import-metrics.sh
+++ b/scripts/utils/import-metrics.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Script using mimirtool for prometheus tsdb collection
+#
+# Usage: ./import-metrics.sh path/to/kubeconfig.yaml
+#
+# Important: Must set inputs for selector and time range
+# 
+# For all metrics use selector='{__name__!=""}'
+# Time format YYYY-MM-DDThh:mm:ssZ  ex: "2025-01-31T00:00:00Z"
+# bash helpers: 
+#      date -u +"%Y-%m-%dT%H:%M:%SZ"
+#      date -u -v-3H +"%Y-%m-%dT%H:%M:%SZ"
+#      [-v[+|-]val[y|m|w|d|H|M|S]]
+selector='{__name__!=""}' 
+from="$(date -u -v-2H +"%Y-%m-%dT%H:%M:%SZ")"
+to="$(date -u -v-0H +"%Y-%m-%dT%H:%M:%SZ")"
+
+# set kubeconfig
+export KUBECONFIG=$1
+
+#TODO: confirm access to cluster
+#TODO: check and increase memory for prometheus installation
+
+# set timestamp, create dir for export path, set permissions, navigate
+st1=$(date +"%Y-%m-%d")
+mkdir -p $PWD/metrics-$st1
+chmod +x metrics-$st1
+cd metrics-$st1
+
+# clean any previous mimirtool pod
+#kubectl delete pod -n cattle-monitoring-system mimirtool
+
+# run script for mimirtool via kubectl on target cluster
+bash -c "./../import-metrics-mimirtool.sh $1" &
+
+#TODO: improve wait
+sleep 5
+
+# from separate mimirtool shell execute remote read
+kubectl exec -n cattle-monitoring-system mimirtool --insecure-skip-tls-verify -i -t -- mimirtool remote-read export --tsdb-path ./prometheus-export --address http://rancher-monitoring-prometheus:9090 --remote-read-path /api/v1/read --to=$to --from=$from --selector $selector
+
+# compress metrics data from export
+kubectl exec -n cattle-monitoring-system mimirtool --insecure-skip-tls-verify -i -t -- tar zcf /tmp/prometheus-export.tar.gz ./prometheus-export
+
+# set filename timestamp
+st2=$(date +"%Y-%m-%d--%H-%M")
+
+# copy exported metrics data to timestamped tarball
+kubectl -n cattle-monitoring-system cp mimirtool:/tmp/prometheus-export.tar.gz ./prometheus-export-${st2}.tar.gz
+
+# unpack, navigate
+tar xf prometheus-export-$st2.tar.gz
+cd prometheus-export
+
+# aggregate tsdb
+cp -R `ls | grep -v "wal"` ../
+
+# cleanup
+cd ../
+rm -rf prometheus-export
+
+# kill mimirtool pod
+kubectl delete pod -n cattle-monitoring-system mimirtool
+
+# run prometheus graph on metrics data (locally via docker), overlapping/obsolete blocks are deleted during compaction
+docker run --rm -u "$(id -u)" -ti -p 9090:9090 -v $PWD:/prometheus rancher/mirrored-prometheus-prometheus:v2.42.0 --storage.tsdb.path=/prometheus --storage.tsdb.retention.time=1y --config.file=/dev/null
+


### PR DESCRIPTION
## Problem
While determining the use cases and functionality for the `dartboard summarize` feature, the Bullseye QA team decided there is also a need for a quick/simple way to obtain metrics data from _any_ Rancher setup via kubeconfig.


## Solution
A script utilizing a Grafana mimirtool pod to make Prometheus queries via `mimirtool remote-read export` to obtain TSDB that are then compressed and copied to local storage.


## Testing
Successful runs across all current major Rancher versions for various time ranges up to 36hrs have been completed however, some flaky behaviors and limitations still exist. 

### Known issues and limitations
The Prometheus pod may incur a memory limit error on pulls larger than 1hr or from attempting more than two 1hr pulls in succession with default memory allocation of 3GB. Viewing the Prometheus workloads in Rancher will display `Terminated with 137: OOMKilled`
 - Workaround: Since data loss may occur, prior to triggering behaviors for metrics capture, increase Prometheus installation memory(10GB) and/or limit queries of **all metrics** to 1hr or less

When viewing TSDB data locally, compaction may fail on overlapping data from separate remote-read exports due to checksum and metadata errors
`level=error component=tsdb msg="Failed to read meta.json for a block during reloadBlocks. Skipping"`
`populate block: chunk iter: cannot populate chunk 9591214 from block 01JKFC2363AE851AKG8M920S3R: checksum mismatch expected:0, actual:74f397f"`
 - Workaround: Each export is containted in its own tarball, TSDBs can be viewed separately

Larger pulls may incur a sample limit error `HTTP status 400 Bad Request: exceeded sample limit (50000000)` There is a solution when using a full mimir chart installation but adding the desired params `--env config.expand-env=true --env querier.max-samples=100000000` to the pod has no effect
 - Workaround: Limit query scope on selector or time range to keep sample quantity under 50,000,000
 
 **Issues and limitations to be addressed in this PR, a future PR and/or encapsulated as a part of `dartboard summarize` functionality.
