### PR TITLE
k6/create_k8s_resources: script improvements

### DIFF
--- a/k6/create_k8s_resources.js
+++ b/k6/create_k8s_resources.js
@@ -7,9 +7,9 @@ import * as k8s from './k8s.js'
 const namespace = __ENV.NAMESPACE || "scalability-test"
 const configMapCount = Number(__ENV.CONFIG_MAP_COUNT)
 const secretCount = Number(__ENV.SECRET_COUNT)
-const vus = 1
 const dataSize = Number(__ENV.DATA_SIZE || 10*1024)
 const data = encoding.b64encode("a".repeat(dataSize))
+const vus = Number(__ENV.VUS || 11)
 
 // Option setting
 const kubeconfig = k8s.kubeconfig(__ENV.KUBECONFIG, __ENV.CONTEXT)

--- a/k6/create_k8s_resources.js
+++ b/k6/create_k8s_resources.js
@@ -72,7 +72,7 @@ export function createConfigMaps() {
             "name": name,
             "namespace": namespace
         },
-        "data": {"data": data.toString}
+        "data": {"data": data}
     }
 
     k8s.create(`${baseUrl}/api/v1/namespaces/${namespace}/configmaps`, body)

--- a/k6/create_k8s_resources.js
+++ b/k6/create_k8s_resources.js
@@ -4,7 +4,7 @@ import { Gauge } from 'k6/metrics';
 import * as k8s from './k8s.js'
 
 // Parameters
-const namespace = "scalability-test"
+const namespace = __ENV.NAMESPACE || "scalability-test"
 const configMapCount = Number(__ENV.CONFIG_MAP_COUNT)
 const secretCount = Number(__ENV.SECRET_COUNT)
 const data = encoding.b64encode("a".repeat(10*1024))

--- a/k6/create_k8s_resources.js
+++ b/k6/create_k8s_resources.js
@@ -7,8 +7,9 @@ import * as k8s from './k8s.js'
 const namespace = __ENV.NAMESPACE || "scalability-test"
 const configMapCount = Number(__ENV.CONFIG_MAP_COUNT)
 const secretCount = Number(__ENV.SECRET_COUNT)
-const data = encoding.b64encode("a".repeat(10*1024))
 const vus = 1
+const dataSize = Number(__ENV.DATA_SIZE || 10*1024)
+const data = encoding.b64encode("a".repeat(dataSize))
 
 // Option setting
 const kubeconfig = k8s.kubeconfig(__ENV.KUBECONFIG, __ENV.CONTEXT)


### PR DESCRIPTION
Part of the work for an upcoming kine investigation benchmark.

- fixes a bug where empty configmaps were creating instead of having the defined content
- makes the script optionally parametric by namespace, data size, and vus. By default nothing changes
