### PR TITLE
k6: add benchmark for listing resources directly from Kubernetes

### DIFF
--- a/k6/k8s.js
+++ b/k6/k8s.js
@@ -6,7 +6,6 @@ import * as YAML from './lib/js-yaml-4.1.0.mjs'
 
 import { URL } from './lib/url-1.0.0.js';
 
-const limit = 5000
 const timeout = '3600s'
 
 // loads connection variables from kubeconfig's specified context
@@ -59,7 +58,7 @@ export function del(url){
 const continueRegex = /"continue":"([A-Za-z0-9]+)"/;
 
 // lists k8s resources
-export function list(url) {
+export function list(url, limit) {
     let _continue = 'first'
     let responses = []
 

--- a/k6/k8s_api_benchmark.js
+++ b/k6/k8s_api_benchmark.js
@@ -1,0 +1,41 @@
+import * as k8s from './k8s.js'
+
+// Parameters
+const vus = __ENV.VUS || 1
+const perVuIterations = __ENV.PER_VU_ITERATIONS || 30
+const resource = __ENV.RESOURCE || "configmaps"
+const limit = __ENV.LIMIT || 5000
+const namespace = __ENV.NAMESPACE || "scalability-test"
+const kubeconfig = k8s.kubeconfig(__ENV.KUBECONFIG, __ENV.CONTEXT)
+const baseUrl = __ENV.BASE_URL
+
+// Option setting
+export const options = {
+    insecureSkipTLSVerify: true,
+
+    tlsAuth: [
+        {
+            cert: kubeconfig["cert"],
+            key: kubeconfig["key"],
+        },
+    ],
+
+    scenarios: {
+        list : {
+            executor: 'per-vu-iterations',
+            exec: 'list',
+            vus: vus,
+            iterations: perVuIterations,
+            maxDuration: '24h',
+        }
+    },
+    thresholds: {
+        checks: ['rate>0.99']
+    }
+}
+
+// Test functions, in order of execution
+
+export function list() {
+    k8s.list(`${baseUrl}/api/v1/namespaces/${namespace}/${resource}`, limit)
+}


### PR DESCRIPTION
Part of the work for an upcoming kine investigation benchmark.

Here I am adding a script to benchmark "list" performance straight from Kubernetes (eg. not through Steve or Norman).

Fundamentally we had code to test that, but it was unused. This adds a k6 script to make use of it, and add a parameter for good measure.