### PR TITLE
tofu/aws: bugfix: correct vpc creation logic

### DIFF
--- a/tofu/modules/aws/network/data.tf
+++ b/tofu/modules/aws/network/data.tf
@@ -29,7 +29,7 @@ data "aws_subnet" "public" {
 }
 
 data "aws_subnet" "private" {
-  count = local.create_vpc ? 0 : 1
+  count = !local.create_vpc ? 1 : 0
   vpc_id = one(data.aws_vpc.existing[*].id)
   availability_zone = var.availability_zone
 
@@ -40,7 +40,7 @@ data "aws_subnet" "private" {
 }
 
 data "aws_subnet" "secondary_private" {
-  count = local.create_vpc && var.secondary_availability_zone != null ? 0 : 1
+  count = !local.create_vpc && var.secondary_availability_zone != null ? 1 : 0
   vpc_id = one(data.aws_vpc.existing[*].id)
   availability_zone = var.secondary_availability_zone
 

--- a/tofu/modules/aws/network/outputs.tf
+++ b/tofu/modules/aws/network/outputs.tf
@@ -3,7 +3,7 @@ output "config" {
     availability_zone : var.availability_zone,
     public_subnet_id : local.public_subnet_id,
     private_subnet_id : local.private_subnet_id,
-    secondary_private_subnet_id : var.secondary_availability_zone != null ? local.secondary_private_subnet_id : null,
+    secondary_private_subnet_id : local.secondary_private_subnet_id,
     public_security_group_id : aws_security_group.public.id,
     private_security_group_id : aws_security_group.private.id,
     ssh_key_name : aws_key_pair.key_pair.key_name,


### PR DESCRIPTION
At the moment deploying to AWS with creation of own VPC is broken and states fail with the following error:

```
2025/05/30 11:26:40 error while running tofu: ╷
│ Error: no matching EC2 Subnet found
│
│   with module.network.data.aws_subnet.secondary_private[0],
│   on ../../modules/aws/network/data.tf line 42, in data "aws_subnet" "secondary_private":
│   42: data "aws_subnet" "secondary_private" {
│
```

This shuffles around the logic a bit in a way that it feels more readable _to me personally_.

Still not very easy to follow, but hopefully correct and a little bit better.