### PR TITLE
Harvester Image IDs: make them node_module_variables

### DIFF
--- a/darts/harvester.yaml
+++ b/darts/harvester.yaml
@@ -55,6 +55,8 @@ tofu_variables:
 # Uncomment to override the image created by the create_image flag above
 #      image_name: openSUSE-leap-micro-6.0
 #      image_namespace: harvester-public
+# Alternatively uncomment the following to set an ID
+#      image_id: default-image-h6dwf
 
       ssh_shared_public_keys: [
 # Uncomment to add shared keys that exist in Harvester
@@ -84,6 +86,8 @@ tofu_variables:
   # Uncomment to override the image created by the create_image flag above
   #      image_name: openSUSE-leap-micro-6.0
   #      image_namespace: harvester-public
+  # Alternatively uncomment the following to set an ID
+  #      image_id: default-image-h6dwf
 
       ssh_shared_public_keys: [
         # Uncomment to add shared keys that exist in Harvester
@@ -114,6 +118,8 @@ tofu_variables:
   # Uncomment to override the image created by the create_image flag above
   #      image_name: openSUSE-leap-micro-6.0
   #      image_namespace: harvester-public
+  # Alternatively uncomment the following to set an ID
+  #      image_id: default-image-h6dwf
 
       ssh_shared_public_keys: [
         # Uncomment to add shared keys that exist in Harvester

--- a/tofu/main/harvester/main.tf
+++ b/tofu/main/harvester/main.tf
@@ -35,7 +35,6 @@ module "test_environment" {
   ssh_user                         = var.ssh_user
   ssh_private_key_path             = var.ssh_private_key_path
   network_config                   = module.network.config
-  image_id                         = var.create_image ? harvester_image.created[0].id : null
   first_kubernetes_api_port        = var.first_kubernetes_api_port
   first_app_http_port              = var.first_app_http_port
   first_app_https_port             = var.first_app_https_port

--- a/tofu/modules/generic/k3s/main.tf
+++ b/tofu/modules/generic/k3s/main.tf
@@ -21,7 +21,6 @@ module "server_nodes" {
   node_module           = var.node_module
   node_module_variables = var.node_module_variables
   network_config        = var.network_config
-  image_id              = var.image_id
 }
 
 module "agent_nodes" {
@@ -34,7 +33,6 @@ module "agent_nodes" {
   node_module           = var.node_module
   node_module_variables = var.node_module_variables
   network_config        = var.network_config
-  image_id              = var.image_id
 }
 
 resource "ssh_sensitive_resource" "first_server_installation" {

--- a/tofu/modules/generic/k3s/variables.tf
+++ b/tofu/modules/generic/k3s/variables.tf
@@ -102,11 +102,3 @@ variable "network_config" {
   description = "Network module outputs, to be passed to node_module"
   type        = any
 }
-
-# Only used for Harvester module atm
-variable "image_id" {
-  description = "ID of a Harvester image, if one was created. Otherwise null"
-  type        = string
-  default     = null
-  nullable    = true
-}

--- a/tofu/modules/generic/node/main.tf
+++ b/tofu/modules/generic/node/main.tf
@@ -8,7 +8,6 @@ module "host" {
   host_configuration_commands = var.host_configuration_commands
   node_module_variables       = var.node_module_variables
   network_config              = var.network_config
-  image_id                    = var.image_id
   public                      = var.public
 }
 

--- a/tofu/modules/generic/node/variables.tf
+++ b/tofu/modules/generic/node/variables.tf
@@ -49,11 +49,3 @@ variable "network_config" {
   description = "Network module outputs, to be passed to node_module"
   type        = any
 }
-
-# Only used for Harvester module atm
-variable "image_id" {
-  description = "ID of a Harvester image, if one was created. Otherwise null"
-  type        = string
-  default     = null
-  nullable    = true
-}

--- a/tofu/modules/generic/rke2/main.tf
+++ b/tofu/modules/generic/rke2/main.tf
@@ -22,7 +22,6 @@ module "server_nodes" {
   node_module           = var.node_module
   node_module_variables = var.node_module_variables
   network_config        = var.network_config
-  image_id              = var.image_id
 }
 
 module "agent_nodes" {
@@ -35,7 +34,6 @@ module "agent_nodes" {
   node_module           = var.node_module
   node_module_variables = var.node_module_variables
   network_config        = var.network_config
-  image_id              = var.image_id
 }
 
 resource "ssh_sensitive_resource" "first_server_installation" {

--- a/tofu/modules/generic/rke2/variables.tf
+++ b/tofu/modules/generic/rke2/variables.tf
@@ -97,11 +97,3 @@ variable "network_config" {
   description = "Network module outputs, to be passed to node_module"
   type        = any
 }
-
-# Only used for Harvester module atm
-variable "image_id" {
-  description = "ID of a Harvester image, if one was created. Otherwise null"
-  type        = string
-  default     = null
-  nullable    = true
-}

--- a/tofu/modules/generic/test_environment/main.tf
+++ b/tofu/modules/generic/test_environment/main.tf
@@ -23,7 +23,6 @@ module "upstream_cluster" {
   ssh_user                  = var.ssh_user
   node_module               = var.node_module
   network_config            = var.network_config
-  image_id                  = var.image_id
   node_module_variables     = var.upstream_cluster.node_module_variables
 }
 
@@ -46,7 +45,6 @@ module "tester_cluster" {
   ssh_user                  = var.ssh_user
   node_module               = var.node_module
   network_config            = var.network_config
-  image_id                  = var.image_id
   node_module_variables     = var.tester_cluster.node_module_variables
 }
 
@@ -70,6 +68,5 @@ module "downstream_clusters" {
   ssh_user                  = var.ssh_user
   node_module               = var.node_module
   network_config            = var.network_config
-  image_id                  = var.image_id
   node_module_variables     = local.downstream_clusters[count.index].node_module_variables
 }

--- a/tofu/modules/generic/test_environment/variables.tf
+++ b/tofu/modules/generic/test_environment/variables.tf
@@ -23,14 +23,6 @@ variable "network_config" {
   type        = any
 }
 
-# Only used for Harvester module atm
-variable "image_id" {
-  description = "ID of a Harvester image, if one was created. Otherwise null"
-  type        = string
-  default     = null
-  nullable    = true
-}
-
 # Upstream cluster specifics
 variable "upstream_cluster" {
   type = object({

--- a/tofu/modules/harvester/node/main.tf
+++ b/tofu/modules/harvester/node/main.tf
@@ -38,7 +38,7 @@ resource "harvester_virtualmachine" "this" {
       size       = "${disk.value.size}Gi"
       bus        = disk.value.bus
       image      = index(var.node_module_variables.disks, disk.value) == 0 ? (
-        var.node_module_variables.image_name != null && var.node_module_variables.image_namespace != null ? data.harvester_image.this[0].id : var.image_id
+        var.node_module_variables.image_name != null && var.node_module_variables.image_namespace != null ? data.harvester_image.this[0].id : var.node_module_variables.image_id
       ) : null
       boot_order = index(var.node_module_variables.disks, disk.value) + 1 //boot_order starts at 1, while the index() function is 0-based
       auto_delete = true

--- a/tofu/modules/harvester/node/variables.tf
+++ b/tofu/modules/harvester/node/variables.tf
@@ -44,6 +44,7 @@ variable "node_module_variables" {
     Harvester-specific VM configuration variables.
     image_name: Image name for this VM. If null, the image created by the network module will be used
     image_namespace: Namespace for image_name. If null, the image created by the network module will be used
+    image_id: Image ID as an alternative to name and namespace. If null, the image created by the network module will be used
     cpu: Number of CPUs to allocate for the VM(s)
     memory: Number of GB of Memory to allocate for the VM(s)
     tags: A map of strings to add as VM tags
@@ -56,6 +57,7 @@ variable "node_module_variables" {
   type = object({
     image_name      = optional(string)
     image_namespace = optional(string)
+    image_id        = optional(string)
     cpu             = number
     memory          = number
     tags            = optional(map(string))
@@ -127,11 +129,4 @@ variable "network_config" {
     ssh_bastion_user     = optional(string)
     ssh_bastion_key_path = optional(string)
   })
-}
-
-variable "image_id" {
-  description = "ID of a Harvester image, if one was created. Otherwise null"
-  type        = string
-  default     = null
-  nullable    = true
 }


### PR DESCRIPTION
In the current `main` an `image_id` for exclusive Harvester use was introduced as a generic variable for any infrastructure - on top of arguably being a bit "forced" on other backends it actually breaks them, for example AWS:

```
2025/05/30 11:23:53 error while running tofu:
│ Error: Unsupported argument
│
│   on ../../modules/generic/node/main.tf line 11, in module "host":
│   11:   image_id                    = var.image_id
│
│ An argument named "image_id" is not expected here.
```


Ideally, any variables that are specific to a certain backend should live either in `node_module_variables` or `network_module_variables`, while generic modules should only contain variables that apply to any backends - or at least the majority of them.

In this case, given it is about nodes, I believe this image_id should really go to `node_module_variables` and remain a Harvester-specific setting.

This PR attempts to resolve that, under the assumption that the intention was to be able to override the image by ID, instead of by name+namespace (which was already supported).

If that was not the intention, let's please discuss this at the next feasible occasion.

Unfortunately I could not test it on Harvester, although it does fix the problem on AWS.

I hope this helps
