### PR TITLE
Make path to ssh scripts absolute

### DIFF
--- a/tofu/modules/generic/k3s/outputs.tf
+++ b/tofu/modules/generic/k3s/outputs.tf
@@ -33,9 +33,9 @@ output "config" {
     }
 
     node_access_commands = merge({
-      for node in module.server_nodes : node.name => node.ssh_script_filename
+      for node in module.server_nodes : node.name => abspath(node.ssh_script_filename)
       }, {
-      for node in module.agent_nodes : node.name => node.ssh_script_filename
+      for node in module.agent_nodes : node.name => abspath(node.ssh_script_filename)
     })
     ingress_class_name          = null
     reserve_node_for_monitoring = var.reserve_node_for_monitoring


### PR DESCRIPTION
This clarifies the output of `dartboard get-access` as currently kubeconfig paths are absolute but SSH script paths are not, and this can confuse users.


With this patch, all paths become absolute so that no ambiguity is left.