### PR TITLE
bugfix: kubectl run does not have --http-debug

### DIFF
--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -241,7 +241,7 @@ func K6run(kubeconfig, testPath string, envVars, tags map[string]string, printLo
 		output = os.Stdout
 	}
 
-	err = Exec(kubeconfig, output, "run", "k6", "--http-debug=full", "--image="+k6Image, "--namespace=tester", "--rm", "--stdin", "--restart=Never", "--overrides="+string(overrideJSON))
+	err = Exec(kubeconfig, output, "run", "k6", "--image="+k6Image, "--namespace=tester", "--rm", "--stdin", "--restart=Never", "--overrides="+string(overrideJSON))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This prevents the following error at `dartboard deploy` time:

```sh
2025/06/06 13:09:06 Import downstream clusters
2025/06/06 13:09:06 Running command:
.bin/kubectl --kubeconfig=/Users/SMOIOLI/synced/repos/dartboard/tofu/main/k3d/default_config/upstream.yaml get services --all-namespaces -o 'jsonpath={.items[0].status.loadBalancer.ingress[0]}'
2025/06/06 13:09:07 Running equivalent of:
./bin/k6 run -e [...]
2025/06/06 13:09:07 Running command:
.bin/kubectl --kubeconfig=/Users/SMOIOLI/synced/repos/dartboard/tofu/main/k3d/default_config/tester.yaml run k6 --http-debug=full [...]:
error: unknown flag: --http-debug
See 'kubectl run --help' for usage.
```

The problem is the flag was added to the kubectl run line, which accepts `k6` as the container name, but does not automatically pass options down to the executable in the container (in this case, k6).

If this is really needed, it can be added to the `args` map earlier in the `K6run` function.