### PR TITLE
Use unique user name in kubeconfig files for k3s and rke2

### DIFF
--- a/tofu/modules/generic/k3s/main.tf
+++ b/tofu/modules/generic/k3s/main.tf
@@ -192,7 +192,7 @@ resource "local_file" "kubeconfig" {
       {
         context = {
           cluster = var.name
-          user : "master-user"
+          user = "admin@${var.name}"
         }
         name = var.name
       }
@@ -206,7 +206,7 @@ resource "local_file" "kubeconfig" {
           client-certificate-data : base64encode(tls_locally_signed_cert.master_user.cert_pem)
           client-key-data : base64encode(tls_private_key.master_user.private_key_pem)
         }
-        name : "master-user"
+        name = "admin@${var.name}"
       }
     ]
   })

--- a/tofu/modules/generic/rke2/main.tf
+++ b/tofu/modules/generic/rke2/main.tf
@@ -186,7 +186,7 @@ resource "local_file" "kubeconfig" {
       {
         context = {
           cluster = var.name
-          user : "master-user"
+          user = "admin@${var.name}"
         }
         name = var.name
       }
@@ -200,7 +200,7 @@ resource "local_file" "kubeconfig" {
           client-certificate-data : base64encode(tls_locally_signed_cert.master_user.cert_pem)
           client-key-data : base64encode(tls_private_key.master_user.private_key_pem)
         }
-        name : "master-user"
+        name = "admin@${var.name}"
       }
     ]
   })


### PR DESCRIPTION
Using unique names allows multiple kubeconfigs to be specified in KUBECONFIG or merged into single kubeconfig file.

```
KUBECONFIG="$PWD/upstream.yaml:$PWD/downstream-0-0.yaml"
kubectl config view --flatten --raw > kubeconfig-all.yaml
```

Apparently the user name has no connection to the common name in the certificate.