### PR TITLE
bugfix: allow for a larger bastion to accommodate larger setups

### DIFF
--- a/tofu/modules/aws/network/variables.tf
+++ b/tofu/modules/aws/network/variables.tf
@@ -43,7 +43,7 @@ variable "bastion_host_ami" {
 
 variable "bastion_host_instance_type" {
   description = "EC2 instance type"
-  default     = "t4g.small"
+  default     = "t4g.large"
 }
 
 # Variables for existing VPC configuration


### PR DESCRIPTION
OOM kills of SSH have been observed when deploying 100 clusters, the default (2 GiB of RAM) is definitely too little. Bumping to 8