### PR TITLE
Kine/Postgres: various fixes

### DIFF
--- a/tofu/modules/generic/postgres/install_postgres.sh
+++ b/tofu/modules/generic/postgres/install_postgres.sh
@@ -73,30 +73,3 @@ su - postgres -c psql <<EOF
   GRANT ALL ON DATABASE kine TO kineuser;
   ALTER DATABASE kine OWNER TO kineuser;
 EOF
-
-# Install kine
-if [ -s /tmp/kine ]; then
-  mv -f /tmp/kine /usr/bin/kine
-else
-  curl -L -o /usr/bin/kine https://github.com/k3s-io/kine/releases/download/${kine_version}/kine-`uname -m | sed 's/x86_64/amd64/'`
-  chmod +x /usr/bin/kine
-fi
-
-cat >/etc/systemd/system/kine.service <<EOF
-[Unit]
-Description=kine
-
-[Service]
-ExecStart=/usr/bin/kine --endpoint postgres://kineuser:kinepassword@localhost:5432/kine?sslmode=disable
-%{ if gogc != null ~}
-Environment="GOGC=${gogc}"
-%{ endif ~}
-
-[Install]
-WantedBy=multi-user.target
-EOF
-systemctl daemon-reload
-
-# Start kine
-systemctl enable kine
-systemctl start kine

--- a/tofu/modules/generic/postgres/main.tf
+++ b/tofu/modules/generic/postgres/main.tf
@@ -26,15 +26,7 @@ resource "ssh_resource" "install_postgres" {
   bastion_user = var.network_config.ssh_user
 
   file {
-    source      = var.kine_executable != null ? var.kine_executable : "/dev/null"
-    destination = "/tmp/kine"
-    permissions = "0755"
-  }
-
-  file {
     content = templatefile("${path.module}/install_postgres.sh", {
-      gogc         = tostring(var.gogc)
-      kine_version = var.kine_version
     })
     destination = "/root/install_postgres.sh"
     permissions = "0700"

--- a/tofu/modules/generic/postgres/main.tf
+++ b/tofu/modules/generic/postgres/main.tf
@@ -11,6 +11,7 @@ module "server_node" {
   project_name          = var.project_name
   name                  = "${var.name}-server"
   ssh_private_key_path  = var.ssh_private_key_path
+  ssh_user              = var.ssh_user
   node_module           = var.node_module
   node_module_variables = var.node_module_variables
   network_config        = var.network_config
@@ -23,7 +24,7 @@ resource "ssh_resource" "install_postgres" {
   private_key  = file(var.ssh_private_key_path)
   user         = var.ssh_user
   bastion_host = var.network_config.ssh_bastion_host
-  bastion_user = var.network_config.ssh_user
+  bastion_user = var.network_config.ssh_bastion_user
 
   file {
     content = templatefile("${path.module}/install_postgres.sh", {

--- a/tofu/modules/generic/postgres/outputs.tf
+++ b/tofu/modules/generic/postgres/outputs.tf
@@ -1,0 +1,6 @@
+// connect with
+// PGPASSWORD=kinepassword psql -U kineuser -h localhost kine
+
+output "datastore_endpoint" {
+  value = "postgres://kineuser:kinepassword@${module.server_node.private_name}/kine"
+}

--- a/tofu/modules/generic/postgres/variables.tf
+++ b/tofu/modules/generic/postgres/variables.tf
@@ -19,23 +19,6 @@ variable "ssh_private_key_path" {
   type        = string
 }
 
-variable "gogc" {
-  description = "Tunable parameter for Go's garbage collection, see: https://tip.golang.org/doc/gc-guide"
-  type        = number
-  default     = null
-}
-
-variable "kine_version" {
-  description = "Kine version"
-  default     = "v0.9.8"
-}
-
-variable "kine_executable" {
-  description = "Overrides kine_version by copying an executable from this path"
-  type        = string
-  default     = null
-}
-
 variable "node_module" {
   description = "Non-generic module to create nodes"
   type        = string

--- a/tofu/modules/generic/postgres_kine/install_postgres.sh
+++ b/tofu/modules/generic/postgres_kine/install_postgres.sh
@@ -27,6 +27,9 @@ ls /var/lib/pgsql/15/initdb.log || /usr/pgsql-15/bin/postgresql-15-setup initdb
 
 # Set basic tuning parameters
 cat >>/var/lib/pgsql/15/data/postgresql.conf <<EOF
+# Listen to any incoming connections
+listen_addresses = '*'
+
 # Tuning parameters from https://pgtune.leopard.in.ua/ based on instance type m6id.4xlarge
 # DB Version: 15
 # OS Type: linux
@@ -52,6 +55,11 @@ max_worker_processes = 16
 max_parallel_workers_per_gather = 4
 max_parallel_workers = 16
 max_parallel_maintenance_workers = 4
+EOF
+
+cat >>/var/lib/pgsql/15/data/pg_hba.conf <<EOF
+# Password-authenticate any incoming connections
+host    all             all             0.0.0.0/0            scram-sha-256
 EOF
 
 # Start DB

--- a/tofu/modules/generic/postgres_kine/install_postgres.sh
+++ b/tofu/modules/generic/postgres_kine/install_postgres.sh
@@ -20,7 +20,7 @@ if [ -d /data ]; then
   mkdir -p /data/pgsql
   mv /var/lib/pgsql /data/pgsql
   ln -sf /data/pgsql /var/lib/pgsql
-endif
+fi
 
 # Initialize the database and enable automatic start
 ls /var/lib/pgsql/15/initdb.log || /usr/pgsql-15/bin/postgresql-15-setup initdb

--- a/tofu/modules/generic/postgres_kine/install_postgres.sh
+++ b/tofu/modules/generic/postgres_kine/install_postgres.sh
@@ -18,6 +18,7 @@ yum install -y postgresql15 postgresql15-server
 # use data disk if available (see mount_ephemeral.sh)
 if [ -d /data ]; then
   mkdir -p /data/pgsql
+  mv /var/lib/pgsql /data/pgsql
   ln -sf /data/pgsql /var/lib/pgsql
 endif
 

--- a/tofu/modules/generic/postgres_kine/outputs.tf
+++ b/tofu/modules/generic/postgres_kine/outputs.tf
@@ -1,6 +1,0 @@
-// connect with
-// PGPASSWORD=kinepassword psql -U kineuser -h localhost kine
-
-output "private_name" {
-  value = module.server_node.private_name
-}


### PR DESCRIPTION
This follows up work on the latest Kine benchmarks

 - the first two commits, and the last are tritival bugfixes - regressions introduced in the module refactorings
 - third opens up Postgres to be connected from any hosts for easier inspection
 - fourth assumes we want to test the kine version that's bundled within RKE2 or k3s, since in most cases it's what we really need. Previous code allowed to install a standalone Kine for a specific reason that I do not think we will ever need again

I hope this helps