### PR TITLE
Fix inclusion of custom rke2 config for maxPods

### DIFF
--- a/tofu/modules/generic/rke2/install_rke2.sh
+++ b/tofu/modules/generic/rke2/install_rke2.sh
@@ -62,7 +62,8 @@ tls-san:
 %{ for san in sans ~}
   - ${jsonencode(san)}
 %{ endfor ~}
-kubelet-arg: "config=/etc/rancher/rke2/kubelet-custom.config"
+kubelet-arg:
+- "--config=/etc/rancher/rke2/kubelet-custom.config"
 kube-controller-manager-arg: "node-cidr-mask-size=${node_cidr_mask_size}"
 EOF
 


### PR DESCRIPTION
According to 
* https://www.suse.com/support/kb/doc/?id=000021093
* https://www.suse.com/support/kb/doc/?id=000021322

The syntax for including a custom config is a bit different:
```
kubelet-arg:
  - "--config=/etc/kubernetes/kubeletconfig.yml"
```

I could verify that after this change the node has the desired maxPods in its manifest and in the config file:

```
# grep maxPods /var/lib/rancher/rke2/agent/etc/kubelet.conf.d/10-cli-config.conf
maxPods: 300
```