### PR TITLE
Add override option to Dart files for rancher charts repo

### DIFF
--- a/cmd/dartboard/subcommands/deploy.go
+++ b/cmd/dartboard/subcommands/deploy.go
@@ -279,17 +279,18 @@ func chartInstallRancherIngress(cluster *tofu.Cluster) error {
 
 func chartInstallRancherMonitoring(r *dart.Dart, cluster *tofu.Cluster) error {
 	rancherMinorVersion := strings.Join(strings.Split(r.ChartVariables.RancherVersion, ".")[0:2], ".")
-
-	chartPath := fmt.Sprintf("https://github.com/rancher/charts/raw/release-v%s", rancherMinorVersion)
+	const chartPrefix = "https://github.com/rancher/charts/raw/release-v"
+	chartPath := fmt.Sprintf("%s%s", chartPrefix, rancherMinorVersion)
 
 	if len(r.ChartVariables.RancherAppsRepoOverride) > 0 {
 		chartPath = r.ChartVariables.RancherAppsRepoOverride
 	}
 
+	chartRancherMonitoringCRDRoute := "assets/rancher-monitoring-crd/rancher-monitoring-crd"
 	chartRancherMonitoringCRD := chart{
 		name:      "rancher-monitoring-crd",
 		namespace: "cattle-monitoring-system",
-		path:      fmt.Sprintf("%s/assets/rancher-monitoring-crd/rancher-monitoring-crd-%s.tgz", chartPath, r.ChartVariables.RancherMonitoringVersion),
+		path:      fmt.Sprintf("%s/%s-%s.tgz", chartPath, chartRancherMonitoringCRDRoute, r.ChartVariables.RancherMonitoringVersion),
 	}
 
 	chartVals := map[string]any{
@@ -307,10 +308,11 @@ func chartInstallRancherMonitoring(r *dart.Dart, cluster *tofu.Cluster) error {
 		return err
 	}
 
+	chartRancherMonitoringRoute := "assets/rancher-monitoring/rancher-monitoring"
 	chartRancherMonitoring := chart{
 		name:      "rancher-monitoring",
 		namespace: "cattle-monitoring-system",
-		path:      fmt.Sprintf("%s/assets/rancher-monitoring/rancher-monitoring-%s.tgz", chartPath, r.ChartVariables.RancherMonitoringVersion),
+		path:      fmt.Sprintf("%s/%s-%s.tgz", chartPath, chartRancherMonitoringRoute, r.ChartVariables.RancherMonitoringVersion),
 	}
 
 	clusterAdd, err := getAppAddressFor(*cluster)

--- a/darts/aws.yaml
+++ b/darts/aws.yaml
@@ -63,7 +63,7 @@ chart_variables:
   rancher_replicas: 1
   downstream_rancher_monitoring: true
   admin_password: adminadminadmin
-  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw /dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
+  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw/dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
   rancher_monitoring_version: 104.1.0+up57.0.3 # see https://github.com/rancher/charts/tree/release-v2.9/assets/rancher-monitoring-crd
   cert_manager_version: 1.8.0
   tester_grafana_version: 6.56.5

--- a/darts/aws.yaml
+++ b/darts/aws.yaml
@@ -63,11 +63,18 @@ chart_variables:
   rancher_replicas: 1
   downstream_rancher_monitoring: true
   admin_password: adminadminadmin
+  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw /dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
   rancher_monitoring_version: 104.1.0+up57.0.3 # see https://github.com/rancher/charts/tree/release-v2.9/assets/rancher-monitoring-crd
   cert_manager_version: 1.8.0
   tester_grafana_version: 6.56.5
   rancher_version: 2.9.1
+  # rancher_chart_repo_override: # URL override defining where to pull Rancher's helm chart from
   force_prime_registry: false
+  # extra_environment_variables:
+  # - name: CATTLE_FEATURES
+  #   value: aggregated-roletemplates=true
+  # - name: CATTLE_AGENT_IMAGE
+  #   value: ""
 
 # Use the following for 2.8.6:
 #  rancher_version: 2.8.6

--- a/darts/azure.yaml
+++ b/darts/azure.yaml
@@ -89,7 +89,7 @@ chart_variables:
   rancher_replicas: 1
   downstream_rancher_monitoring: true
   admin_password: adminadminadmin
-  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw /dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
+  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw/dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
   rancher_monitoring_version: 104.1.0+up57.0.3 # see https://github.com/rancher/charts/tree/release-v2.9/assets/rancher-monitoring-crd
   cert_manager_version: 1.8.0
   tester_grafana_version: 6.56.5

--- a/darts/azure.yaml
+++ b/darts/azure.yaml
@@ -89,11 +89,18 @@ chart_variables:
   rancher_replicas: 1
   downstream_rancher_monitoring: true
   admin_password: adminadminadmin
+  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw /dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
   rancher_monitoring_version: 104.1.0+up57.0.3 # see https://github.com/rancher/charts/tree/release-v2.9/assets/rancher-monitoring-crd
   cert_manager_version: 1.8.0
   tester_grafana_version: 6.56.5
   rancher_version: 2.9.1
+  # rancher_chart_repo_override: # URL override defining where to pull Rancher's helm chart from
   force_prime_registry: false
+  # extra_environment_variables:
+  # - name: CATTLE_FEATURES
+  #   value: aggregated-roletemplates=true
+  # - name: CATTLE_AGENT_IMAGE
+  #   value: ""
 
 # Use the following for 2.8.6:
 #  rancher_version: 2.8.6

--- a/darts/harvester.yaml
+++ b/darts/harvester.yaml
@@ -136,7 +136,7 @@ chart_variables:
   rancher_replicas: 1
   downstream_rancher_monitoring: true
   admin_password: adminadminadmin
-  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw /dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
+  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw/dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
   rancher_monitoring_version: 104.1.0+up57.0.3 # see https://github.com/rancher/charts/tree/release-v2.9/assets/rancher-monitoring-crd
   cert_manager_version: 1.8.0
   tester_grafana_version: 6.56.5

--- a/darts/harvester.yaml
+++ b/darts/harvester.yaml
@@ -136,11 +136,18 @@ chart_variables:
   rancher_replicas: 1
   downstream_rancher_monitoring: true
   admin_password: adminadminadmin
+  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw /dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
   rancher_monitoring_version: 104.1.0+up57.0.3 # see https://github.com/rancher/charts/tree/release-v2.9/assets/rancher-monitoring-crd
   cert_manager_version: 1.8.0
   tester_grafana_version: 6.56.5
   rancher_version: 2.9.1
+  # rancher_chart_repo_override: # URL override defining where to pull Rancher's helm chart from
   force_prime_registry: false
+  # extra_environment_variables:
+  # - name: CATTLE_FEATURES
+  #   value: aggregated-roletemplates=true
+  # - name: CATTLE_AGENT_IMAGE
+  #   value: ""
 
 # Use the following for 2.8.6:
 #  rancher_version: 2.8.6
@@ -149,6 +156,10 @@ chart_variables:
 # Add the following to set a custom image:
 #  rancher_image_override: rancher/rancher
 #  rancher_image_tag_override: v2.8.6-debug-1
+
+# Set arbitrary helm values (in yaml format) for installing Rancher
+#  rancher_values: |
+#    features: "my-feature-flag=true"
 
 test_variables:
   test_config_maps: 2000

--- a/darts/k3d.yaml
+++ b/darts/k3d.yaml
@@ -45,11 +45,18 @@ chart_variables:
   rancher_replicas: 1
   downstream_rancher_monitoring: true
   admin_password: adminadminadmin
+  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw /dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
   rancher_monitoring_version: 104.1.0+up57.0.3 # see https://github.com/rancher/charts/tree/release-v2.9/assets/rancher-monitoring-crd
   cert_manager_version: 1.8.0
   tester_grafana_version: 6.56.5
   rancher_version: 2.9.1
+  # rancher_chart_repo_override: # URL override defining where to pull Rancher's helm chart from
   force_prime_registry: false
+  # extra_environment_variables:
+  # - name: CATTLE_FEATURES
+  #   value: aggregated-roletemplates=true
+  # - name: CATTLE_AGENT_IMAGE
+  #   value: ""
 
 # Use the following for 2.8.6:
 #  rancher_version: 2.8.6
@@ -62,7 +69,6 @@ chart_variables:
 # Set arbitrary helm values (in yaml format) for installing Rancher
 #  rancher_values: |
 #    features: "my-feature-flag=true"
-
 
 test_variables:
   test_config_maps: 2000

--- a/darts/k3d.yaml
+++ b/darts/k3d.yaml
@@ -45,7 +45,7 @@ chart_variables:
   rancher_replicas: 1
   downstream_rancher_monitoring: true
   admin_password: adminadminadmin
-  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw /dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
+  # rancher_apps_repo_override: # must be the "raw" link not the "blob" link ex: https://github.com/rancher/charts/raw/dev-v2.11 vs https://github.com/rancher/charts/blob/dev-v2.12
   rancher_monitoring_version: 104.1.0+up57.0.3 # see https://github.com/rancher/charts/tree/release-v2.9/assets/rancher-monitoring-crd
   cert_manager_version: 1.8.0
   tester_grafana_version: 6.56.5

--- a/internal/dart/recipe.go
+++ b/internal/dart/recipe.go
@@ -27,6 +27,7 @@ type ChartVariables struct {
 	AdminPassword               string           `yaml:"admin_password"`
 	RancherVersion              string           `yaml:"rancher_version"`
 	ForcePrimeRegistry          bool             `yaml:"force_prime_registry"`
+	RancherAppsRepoOverride     string           `yaml:"rancher_apps_repo_override"`
 	RancherChartRepoOverride    string           `yaml:"rancher_chart_repo_override"`
 	RancherImageOverride        string           `yaml:"rancher_image_override"`
 	RancherImageTagOverride     string           `yaml:"rancher_image_tag_override"`


### PR DESCRIPTION
Adds an optional override field to Dart files for changing the URL used to pull Rancher App Charts from.

Integrates both `extra_environment_variables` and `rancher_values` from Dart files into the values passed to the `chartInstall(...)` call for Rancher.

Updates example Darts to include examples for both `extra_environment_variables` and `rancher_values`

Closes #78 