### PR TITLE
Update k6 login() func and all k6 scripts that use it

### DIFF
--- a/k6/crds/create_crds.js
+++ b/k6/crds/create_crds.js
@@ -55,7 +55,7 @@ function cleanup(cookies, namePrefix) {
 // Test functions, in order of execution
 export function setup() {
   // log in
-  if (!login(baseUrl, {}, username, password)) {
+  if (login(baseUrl, {}, username, password).status !== 200) {
     fail(`could not login into cluster`)
   }
   const cookies = getCookies(baseUrl)

--- a/k6/crds/delete_crds.js
+++ b/k6/crds/delete_crds.js
@@ -56,7 +56,7 @@ function cleanup(cookies) {
 // Test functions, in order of execution
 export function setup() {
   // log in
-  if (!login(baseUrl, {}, username, password)) {
+  if (login(baseUrl, {}, username, password).status !== 200) {
     fail(`could not login into cluster`)
   }
   const cookies = getCookies(baseUrl)

--- a/k6/crds/get_crds.js
+++ b/k6/crds/get_crds.js
@@ -40,7 +40,7 @@ export const options = {
 
 export function setup() {
   // log in
-  if (!login(baseUrl, {}, username, password)) {
+  if (login(baseUrl, {}, username, password).status !== 200) {
     fail(`could not login into cluster`)
   }
   const cookies = getCookies(baseUrl)

--- a/k6/crds/load_crds.js
+++ b/k6/crds/load_crds.js
@@ -86,7 +86,7 @@ function cleanup(cookies) {
 // Test functions, in order of execution
 export function setup() {
   // log in
-  if (!login(baseUrl, {}, username, password)) {
+  if (login(baseUrl, {}, username, password).status !== 200) {
     fail(`could not login into cluster`);
   }
   const cookies = getCookies(baseUrl);

--- a/k6/crds/update_crds.js
+++ b/k6/crds/update_crds.js
@@ -87,7 +87,7 @@ function cleanup(cookies) {
 // Test functions, in order of execution
 export function setup() {
   // log in
-  if (!login(baseUrl, {}, username, password)) {
+  if (login(baseUrl, {}, username, password).status !== 200) {
     fail(`could not login into cluster`)
   }
   const cookies = getCookies(baseUrl)

--- a/k6/crds/update_destructive_crds.js
+++ b/k6/crds/update_destructive_crds.js
@@ -90,7 +90,7 @@ function cleanup(cookies) {
 // Test functions, in order of execution
 export function setup() {
   // log in
-  if (!login(baseUrl, {}, username, password)) {
+  if (login(baseUrl, {}, username, password).status !== 200) {
     fail(`could not login into cluster`)
   }
   const cookies = getCookies(baseUrl)

--- a/k6/schemas/verify_schema_definitions.js
+++ b/k6/schemas/verify_schema_definitions.js
@@ -91,7 +91,7 @@ function cleanup(cookies) {
 // Test functions, in order of execution
 export function setup() {
   // log in
-  if (!login(baseUrl, {}, username, password)) {
+  if (login(baseUrl, {}, username, password).status !== 200) {
     fail(`could not login into cluster`)
   }
   const cookies = getCookies(baseUrl)

--- a/k6/schemas/verify_schemas.js
+++ b/k6/schemas/verify_schemas.js
@@ -89,7 +89,7 @@ function cleanup(cookies) {
 // Test functions, in order of execution
 export function setup() {
   // log in
-  if (!login(baseUrl, {}, username, password)) {
+  if (login(baseUrl, {}, username, password).status !== 200) {
     fail(`could not login into cluster`)
   }
   const cookies = getCookies(baseUrl)

--- a/k6/tests/tokens.js
+++ b/k6/tests/tokens.js
@@ -43,7 +43,7 @@ export const options = {
 
 export function setup() {
   // log in
-  if (!login(baseUrl, {}, username, password)) {
+  if (login(baseUrl, {}, username, password).status !== 200) {
     fail(`could not login into cluster`)
   }
   const cookies = getCookies(baseUrl)


### PR DESCRIPTION
This function used to return a bool, but now it returns the full response. This allows us some more flexibility in how we use it, while maintaining the previous capability to check the status returned a 200. This change will also allow us to inspect the other fields of the response object, such as the cookies; which we can then extract to login as multiple different users at the same time.