### PR TITLE
Fix k6-test-files ConfigMap misssing some files

### DIFF
--- a/charts/k6-files/templates/configmap.yaml
+++ b/charts/k6-files/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: k6-test-files
 data:
-{{ (.Files.Glob "test-files/*.{js,mjs}").AsConfig | indent 2 }}
+{{ (.Files.Glob "test-files/**.{js,mjs}").AsConfig | indent 2 }}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
After #57, I was getting some errors during setup due to some files missing when running the k6 scripts. I traced it down to the `k6-test-files`, which is mounted as a volume into the k6 container, missing some files due to the new file structure.
```
ERRO[0000] The moduleSpecifier "k6/rancher_setup.js" couldn't be found on local disk.
```

<details>
<summary>Comparisson of files included in the ConfigMap</summary>

* Before these changes:
```
- k8s_api_benchmark.js
- js-yaml-4.1.0.mjs
- k6-summary-0.0.2.js
- papaparse-5.3.2.js
- url-1.0.0.js
```
* After these changes:
```
- api_benchmark.js
- change_config_maps.js
- crd_utils.js
- create_crds.js
- create_k8s_resources.js
- create_projects.js
- create_roles_users.js
- delete_crds.js
- get_crds.js
- js-yaml-4.1.0.mjs
- k6-summary-0.0.2.js
- k8s.js
- k8s_api_benchmark.js
- load_crds.js
- load_steve_k8s_pagination.js
- load_steve_new_pagination.js
- papaparse-5.3.2.js
- rancher_setup.js
- rancher_users_utils.js
- rancher_utils.js
- schema_utils.js
- steve_count_resouces.js
- steve_create_pods.js
- steve_paginated_api_benchmark.js
- tokens.js
- update_crds.js
- update_destructive_crds.js
- url-1.0.0.js
- verify_schema_definitions.js
- verify_schemas.js
- js-yaml-4.1.0.mjs
- k6-summary-0.0.2.js
- papaparse-5.3.2.js
- url-1.0.0.js
```

</details>

It's not the perfect solution, because it will contain some files that belong to a different place (maybe `lib/`?). However, it's a valid workaround