### PR TITLE
Add load test for projects + namespaces

### DIFF
--- a/k6/namespaces/namespace_utils.js
+++ b/k6/namespaces/namespace_utils.js
@@ -1,0 +1,100 @@
+import { check, fail, sleep } from 'k6';
+import http from 'k6/http'
+import { retryUntilExpected } from "../rancher/rancher_utils.js";
+import * as YAML from '../lib/js-yaml-4.1.0.mjs'
+
+export const baseNamespacesPath = "v1/namespaces"
+export const namespaceTag = { url: `/v1/namespaces/<Namespace ID>` }
+export const namespacesTag = { url: `/v1/namespaces` }
+export const postNamespaceTag = { url: `/v1/namespaces` }
+export const putNamespaceTag = { url: `/v1/namespaces/<Namespace ID>` }
+
+
+export function cleanupMatchingNamespaces(baseUrl, cookies, namePrefix) {
+  let res = http.get(`${baseUrl}/${baseNamespacesPath}`, { cookies: cookies })
+  check(res, {
+    '/v1/management.cattle.io.namespaces returns status 200': (r) => r.status === 200,
+  })
+  JSON.parse(res.body)["data"].filter(r => r["metadata"]["name"].startsWith(namePrefix)).forEach(r => {
+    res = http.del(`${baseUrl}/${baseNamespacesPath}/${r["id"]}`, { cookies: cookies })
+    check(res, {
+      'DELETE /v3/namespaces returns status 200': (r) => r.status === 200,
+    })
+  })
+}
+
+export function getNamespace(baseUrl, cookies, id) {
+  let res = http.get(`${baseUrl}/${baseNamespacesPath}`, { cookies: cookies, tag: namespacesTag })
+  let criteria = []
+  criteria[`GET /${baseNamespacesPath} returns status 200`] = (r) => r.status === 200
+  check(res, criteria)
+  namespaceArray = JSON.parse(res.body)["data"].filter(r => r["id"] == id)
+  return { res: res, namespace: namespaceArray[0] }
+}
+
+export function getNamespaces(baseUrl, cookies) {
+  let res = http.get(`${baseUrl}/${baseNamespacesPath}`, { cookies: cookies, tags: namespacesTag })
+  check(res, {
+    'GET /v1/management.cattle.io.namespaces returns status 200': (r) => r.status === 200,
+  })
+  let namespaceArray = JSON.parse(res.body)["data"]
+  return { res: res, namespaceArray: namespaceArray }
+}
+
+export function createNamespace(baseUrl, body, cookies) {
+  const res = http.post(
+    `${baseUrl}/${baseNamespacesPath}`,
+    body,
+    {
+      headers: {
+        "content-type": "application/json",
+      },
+      cookies: cookies,
+      tags: postNamespaceTag,
+    }
+  )
+  check(res, {
+    'Namespace post returns 201 (created)': (r) => r.status === 201,
+  })
+  return res
+}
+
+export function deleteNamespace(baseUrl, cookies, id) {
+  let res = http.del(`${baseUrl}/${baseNamespacesPath}/${id}`, null, { cookies: cookies, tags: namespaceTag })
+
+  check(res, {
+    'DELETE /v3/namespaces returns status 200': (r) => r.status === 200 || r.status === 204,
+  })
+  return res
+}
+
+export function getNamespacesMatchingName(baseUrl, cookies, namePrefix) {
+  let { res, namespaceArray } = getNamespaces(baseUrl, cookies)
+  if (!namespaceArray || namespaceArray.length == 0) {
+    console.log("Could not get list of Namespaces");
+    return { res: res, namespaceArray: [] };
+  }
+  let filteredArray = []
+  filteredArray = namespaceArray.filter(r => r["metadata"]["name"].startsWith(namePrefix))
+  return { res: res, namespaceArray: filteredArray }
+}
+
+export function updateNamespace(baseUrl, cookies, namespace) {
+  let body = YAML.dump(namespace)
+  let res = http.put(
+    `${baseUrl}/${baseNamespacesPath}/${namespace.metadata.name}`,
+    body,
+    {
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/yaml',
+      },
+      cookies: cookies,
+      tags: putNamespaceTag,
+    }
+  )
+  check(res, {
+    'PUT /v3/namespaces/<Namespace ID> returns status 200': (r) => r.status === 200,
+  })
+  return res
+}

--- a/k6/projects/project_utils.js
+++ b/k6/projects/project_utils.js
@@ -1,0 +1,120 @@
+import { check, fail, sleep } from 'k6';
+import http from 'k6/http'
+import { retryUntilExpected } from "../rancher/rancher_utils.js";
+import * as YAML from '../lib/js-yaml-4.1.0.mjs'
+
+export const baseProjectsPath = "v1/management.cattle.io.projects"
+export const normanProjectsPath = "v3/projects"
+export const normanProjectTag = { url: `/v3/projects/<Project ID>` }
+export const normanProjectsTag = { url: `/v3/projects` }
+export const projectsTag = { url: `/v1/management.cattle.io.projects` }
+export const postProjectTag = { url: `/v3/projects` }
+export const putProjectTag = { url: `/v3/projects/<Project ID>` }
+
+
+export function cleanupMatchingProjects(baseUrl, cookies, namePrefix) {
+  let res = http.get(`${baseUrl}/${baseProjectsPath}`, { cookies: cookies })
+  check(res, {
+    '/v1/management.cattle.io.projects returns status 200': (r) => r.status === 200,
+  })
+  JSON.parse(res.body)["data"].filter(r => r["spec"]["displayName"].startsWith(namePrefix)).forEach(r => {
+    res = http.del(`${baseUrl}/${normanProjectsPath}/${r["id"]}`, { cookies: cookies })
+    check(res, {
+      'DELETE /v3/projects returns status 200': (r) => r.status === 200,
+    })
+  })
+}
+
+export function getProject(baseUrl, cookies, id) {
+  let res = http.get(`${baseUrl}/${baseProjectsPath}`, { cookies: cookies, tag: projectsTag })
+  let criteria = []
+  criteria[`GET /${baseProjectsPath} returns status 200`] = (r) => r.status === 200
+  check(res, criteria)
+  let projectArray = JSON.parse(res.body)["data"].filter(r => r["id"] == id)
+  return { res: res, project: projectArray[0] }
+}
+
+export function getProjects(baseUrl, cookies) {
+  let res = http.get(`${baseUrl}/${baseProjectsPath}`, { cookies: cookies, tags: projectsTag })
+  check(res, {
+    'GET /v1/management.cattle.io.projects returns status 200': (r) => r.status === 200,
+  })
+  let projectArray = JSON.parse(res.body)["data"]
+  return { res: res, projectArray: projectArray }
+}
+
+export function getNormanProjects(baseUrl, cookies) {
+  let res = http.get(`${baseUrl}/${normanProjectsPath}`, { cookies: cookies, tags: normanProjectsTag })
+  check(res, {
+    'GET /v3/projects returns status 200': (r) => r.status === 200,
+  })
+  let projectArray = JSON.parse(res.body)["data"]
+  return { res: res, projectArray: projectArray }
+}
+
+export function createNormanProject(baseUrl, body, cookies) {
+  const res = http.post(
+    `${baseUrl}/${normanProjectsPath}`,
+    body,
+    {
+      headers: {
+        "content-type": "application/json",
+      },
+      cookies: cookies,
+      tags: postProjectTag,
+    }
+  )
+  check(res, {
+    'Project post returns 201 (created)': (r) => r.status === 201,
+  })
+  return res
+}
+
+export function deleteNormanProject(baseUrl, cookies, id) {
+  let res = http.del(`${baseUrl}/${normanProjectsPath}/${id}`, null, { cookies: cookies, tags: normanProjectTag })
+
+  check(res, {
+    'DELETE /v3/projects returns status 200': (r) => r.status === 200 || r.status === 204,
+  })
+  return res
+}
+
+export function getProjectsMatchingName(baseUrl, cookies, namePrefix) {
+  let { res, projectArray } = getProjects(baseUrl, cookies)
+  if (!projectArray || projectArray.length === 0) {
+    console.log("Could not get list of Projects");
+    return { res: res, projectArray: [] };
+  }
+  let filteredArray = projectArray.filter(r => r["spec"]["displayName"].startsWith(namePrefix))
+  return { res: res, projectArray: filteredArray }
+}
+
+export function getNormanProjectsMatchingName(baseUrl, cookies, namePrefix) {
+  let { res, projectArray } = getNormanProjects(baseUrl, cookies)
+  if (!projectArray || projectArray.length === 0) {
+    console.log("Could not get list of Projects");
+    return { res: res, projectArray: [] };
+  }
+  let filteredArray = projectArray.filter(r => r["name"].startsWith(namePrefix))
+  return { res: res, projectArray: filteredArray }
+}
+
+export function updateProject(baseUrl, cookies, project) {
+  let body = YAML.dump(project)
+  let res = http.put(
+    `${baseUrl}/${normanProjectsPath}/${project.metadata.name}`,
+    body,
+    {
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/yaml',
+      },
+      cookies: cookies,
+      tags: putProjectTag,
+    }
+  )
+  check(res, {
+    'PUT /v3/projects/<Project ID> returns status 200': (r) => r.status === 200,
+  })
+  return res
+}

--- a/k6/rancher/rancher_diagnostics.js
+++ b/k6/rancher/rancher_diagnostics.js
@@ -1,0 +1,568 @@
+import { check, fail, sleep } from 'k6'
+import { Trend, Gauge } from 'k6/metrics';
+import http from 'k6/http'
+
+
+// Resource count tracking metrics (using Gauges since they represent current state)
+export const totalProjectsGauge = new Gauge('cluster_projects_total')
+export const totalNamespacesGauge = new Gauge('cluster_namespaces_total')
+export const totalPodsGauge = new Gauge('cluster_pods_total')
+export const totalSecretsGauge = new Gauge('cluster_secrets_total')
+export const totalConfigMapsGauge = new Gauge('cluster_configmaps_total')
+export const totalServiceAccountsGauge = new Gauge('cluster_serviceaccounts_total')
+export const totalRolesGauge = new Gauge('roles_total')
+export const totalRoleBindingsGauge = new Gauge('cluster_rolebindings_total')
+export const totalClusterRolesGauge = new Gauge('cluster_clusterroles_total')
+export const totalClusterRoleBindingsGauge = new Gauge('cluster_clusterrolebindings_total')
+export const totalGlobalRoleBindingsGauge = new Gauge('cluster_globalrolebindings_total')
+export const totalCRDsGauge = new Gauge('cluster_crds_total')
+
+// API response time tracking metrics
+export const systemImageAPITime = new Trend('api_systemimage_duration')
+export const eventAPITime = new Trend('api_event_duration')
+export const k8sEventAPITime = new Trend('api_k8sevent_duration')
+export const settingsAPITime = new Trend('api_settings_duration')
+export const clusterRoleAPITime = new Trend('api_clusterrole_duration')
+export const crdAPITime = new Trend('api_crd_duration')
+export const roleAPITime = new Trend('api_role_duration')
+export const roleBindingAPITime = new Trend('api_rolebinding_duration')
+export const clusterRoleBindingAPITime = new Trend('api_clusterrolebinding_duration')
+export const globalRoleBindingAPITime = new Trend('api_globalrolebinding_duration')
+export const rkeAddonAPITime = new Trend('api_rkeaddon_duration')
+export const configMapAPITime = new Trend('api_configmap_duration')
+export const serviceAccountAPITime = new Trend('api_serviceaccount_duration')
+export const secretAPITime = new Trend('api_secret_duration')
+export const podAPITime = new Trend('api_pod_duration')
+export const rkeServiceOptionAPITime = new Trend('api_rkeserviceoption_duration')
+export const apiServiceAPITime = new Trend('api_apiservice_duration')
+export const roleTemplateAPITime = new Trend('api_roletemplate_duration')
+export const projectAPITime = new Trend('api_project_duration')
+export const namespaceAPITime = new Trend('api_namespace_duration')
+
+export const resourceCount = new Gauge('resource_count')
+export const namespaceResourceDensity = new Trend('namespace_resource_density');
+export const resourceDistribution = new Trend('resource_distribution')
+
+export const timingTag = { timing: "yes" }
+export const clusterScopeTag = { scope: "cluster" }
+export const namespaceScopeTag = { scope: "namespace" }
+export const localClusterTag = { cluster: "local" }
+
+export function processMetricsFromCountData(data) {
+  Object.keys(data).forEach(resourceType => {
+    const resourceData = data[resourceType];
+    if (resourceData.totalCount !== undefined) {
+      resourceCount.add(resourceData.totalCount, { resource_type: resourceType, ...clusterScopeTag, ...localClusterTag });
+
+      // If it has namespace-specific data, create namespace-specific metrics
+      if (resourceData.namespaces) {
+        Object.entries(resourceData.namespaces).forEach(([namespace, count]) => {
+          resourceCount.add(count, { resource_type: resourceType, namespace: namespace, ...namespaceScopeTag })
+          namespaceResourceDensity.add(count, { namespace: namespace, resource_type: resourceType })
+
+          // Calculate namespace distribution for this resource type
+          const namespaceCounts = Object.values(resourceData.namespaces)
+          const avgPerNamespace = namespaceCounts.reduce((a, b) => a + b, 0) / namespaceCounts.length
+          const maxPerNamespace = Math.max(...namespaceCounts)
+          const minPerNamespace = Math.min(...namespaceCounts)
+
+          resourceDistribution.add(avgPerNamespace, { resource_type: resourceType, metric: 'avg_per_namespace' })
+          resourceDistribution.add(maxPerNamespace, { resource_type: resourceType, metric: 'max_per_namespace' })
+          resourceDistribution.add(minPerNamespace, { resource_type: resourceType, metric: 'min_per_namespace' })
+
+        });
+      }
+    }
+  });
+}
+
+export function getLocalClusterResourceCounts(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/counts`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+  })
+  check(response, {
+    'k8s/clusters/local/v1/counts can be queried': (r) => r.status === 200,
+  })
+  return JSON.parse(response.body).data[0].counts
+}
+
+export function processResourceCounts(resourceCountObj) {
+  let finalResourceCounts = {}
+
+  if (resourceCountObj && typeof resourceCountObj === 'object') {
+    Object.keys(resourceCountObj).forEach(resourceType => {
+      let resourceData = resourceCountObj[resourceType]
+
+      // Extract clean resource name from type (remove API version prefixes)
+      let resourceName = resourceType.split('.').pop() || resourceType
+
+      let resourceInfo = {}
+
+      // Get total count from summary
+      if (resourceData.summary && resourceData.summary.count !== undefined) {
+        resourceInfo.totalCount = resourceData.summary.count
+      }
+
+      // Get namespaced counts if they exist
+      if (resourceData.namespaces && typeof resourceData.namespaces === 'object') {
+        resourceInfo.namespaces = {}
+        Object.keys(resourceData.namespaces).forEach(namespace => {
+          let namespaceData = resourceData.namespaces[namespace]
+          if (namespaceData.count !== undefined) {
+            resourceInfo.namespaces[namespace] = namespaceData.count
+          }
+        })
+      }
+
+      // Only add to final object if we have some data
+      if (resourceInfo.totalCount !== undefined || resourceInfo.namespaces) {
+        finalResourceCounts[resourceName] = resourceInfo
+      }
+    })
+  }
+
+  return finalResourceCounts
+}
+
+export function getLocalClusterAccessibleDiagnosticsSchemas(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/schemas`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+  })
+
+  return JSON.parse(response.body).data.map(s => s.id)
+}
+
+export function getLocalClusterSystemImages(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/management.cattle.io.rkek8ssystemimage`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/management.cattle.io.rkek8ssystemimage can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterEvents(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/event`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/event can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterK8sEvents(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/events.k8s.io.event`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/events.k8s.io.event can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterSettings(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/management.cattle.io.setting`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/management.cattle.io.setting can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterClusterRoles(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/rbac.authorization.k8s.io.clusterrole`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/rbac.authorization.k8s.io.clusterrole can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterCRDs(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/apiextensions.k8s.io.customresourcedefinition`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/apiextensions.k8s.io.customresourcedefinition can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterRoles(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/rbac.authorization.k8s.io.role`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/rbac.authorization.k8s.io.roles can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterRoleBindings(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/rbac.authorization.k8s.io.rolebinding`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/rbac.authorization.k8s.io.rolebinding can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterClusterRoleBindings(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/rbac.authorization.k8s.io.clusterrolebinding`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/rbac.authorization.k8s.io.clusterrolebinding can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterGlobalRoleBindings(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/management.cattle.io.globalrolebinding`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/management.cattle.io.globalrolebinding can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterRKEAddons(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/management.cattle.io.rkeaddon`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/management.cattle.io.rkeaddon can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterConfigMaps(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/configmap`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/configmap can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterServiceAccounts(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/serviceaccount`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/serviceaccount can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterSecrets(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/secret`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/secret can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterPods(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/pod`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/pod can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterRKEK8sServiceOptions(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/management.cattle.io.rkek8sserviceoption`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/management.cattle.io.rkek8sserviceoption can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterAPIServices(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/apiregistration.k8s.io.apiservice`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/apiregistration.k8s.io.apiservice can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterRoleTemplates(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/management.cattle.io.roletemplate`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/management.cattle.io.roletemplate can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterProjects(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/management.cattle.io.projects`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/management.cattle.io.projects can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function getLocalClusterNamespaces(baseUrl, cookies) {
+  let response = http.get(`${baseUrl}/k8s/clusters/local/v1/namespaces`, {
+    headers: {
+      accept: 'application/json',
+    },
+    cookies: cookies,
+    tags: timingTag
+  })
+  check(response, {
+    'k8s/clusters/local/v1/namespaces can be queried': (r) => r.status === 200,
+  })
+  return response
+}
+
+export function processResourceTimings(baseUrl, cookies) {
+  let timingsArr = {}
+
+  let accessibleSchemas = getLocalClusterAccessibleDiagnosticsSchemas(baseUrl, cookies)
+
+  // Get timing data for each resource type
+  if (accessibleSchemas.includes("management.cattle.io.rkek8ssystemimage")) {
+    let systemImageRes = getLocalClusterSystemImages(baseUrl, cookies)
+    if (systemImageRes.status == 200 && systemImageRes.timings.duration) {
+      timingsArr["management.cattle.io.rkek8ssystemimage"] = systemImageRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("event")) {
+    let eventRes = getLocalClusterEvents(baseUrl, cookies)
+    if (eventRes.status == 200 && eventRes.timings.duration) {
+      timingsArr["event"] = eventRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("events.k8s.io.event")) {
+    let k8sEventRes = getLocalClusterK8sEvents(baseUrl, cookies)
+    if (k8sEventRes.status == 200 && k8sEventRes.timings.duration) {
+      timingsArr["events.k8s.io.event"] = k8sEventRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("management.cattle.io.setting")) {
+    let settingsRes = getLocalClusterSettings(baseUrl, cookies)
+    if (settingsRes.status == 200 && settingsRes.timings.duration) {
+      timingsArr["management.cattle.io.setting"] = settingsRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("rbac.authorization.k8s.io.clusterrole")) {
+    let clusterRoleRes = getLocalClusterClusterRoles(baseUrl, cookies)
+    if (clusterRoleRes.status == 200 && clusterRoleRes.timings.duration) {
+      timingsArr["rbac.authorization.k8s.io.clusterrole"] = clusterRoleRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("apiextensions.k8s.io.customresourcedefinition")) {
+    let crdRes = getLocalClusterCRDs(baseUrl, cookies)
+    if (crdRes.status == 200 && crdRes.timings.duration) {
+      timingsArr["apiextensions.k8s.io.customresourcedefinition"] = crdRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("rbac.authorization.k8s.io.role")) {
+    let roleRes = getLocalClusterRoles(baseUrl, cookies)
+    if (roleRes.status == 200 && roleRes.timings.duration) {
+      timingsArr["rbac.authorization.k8s.io.role"] = roleRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("rbac.authorization.k8s.io.rolebinding")) {
+    let roleBindingRes = getLocalClusterRoleBindings(baseUrl, cookies)
+    if (roleBindingRes.status == 200 && roleBindingRes.timings.duration) {
+      timingsArr["rbac.authorization.k8s.io.rolebinding"] = roleBindingRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("rbac.authorization.k8s.io.clusterrolebinding")) {
+    let clusterRoleBindingRes = getLocalClusterClusterRoleBindings(baseUrl, cookies)
+    if (clusterRoleBindingRes.status == 200 && clusterRoleBindingRes.timings.duration) {
+      timingsArr["rbac.authorization.k8s.io.clusterrolebinding"] = clusterRoleBindingRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("management.cattle.io.globalrolebinding")) {
+    let globalRoleBindingRes = getLocalClusterGlobalRoleBindings(baseUrl, cookies)
+    if (globalRoleBindingRes.status == 200 && globalRoleBindingRes.timings.duration) {
+      timingsArr["management.cattle.io.globalrolebinding"] = globalRoleBindingRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("management.cattle.io.rkeaddon")) {
+    let rkeAddonRes = getLocalClusterRKEAddons(baseUrl, cookies)
+    if (rkeAddonRes.status == 200 && rkeAddonRes.timings.duration) {
+      timingsArr["management.cattle.io.rkeaddon"] = rkeAddonRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("configmap")) {
+    let configMapRes = getLocalClusterConfigMaps(baseUrl, cookies)
+    if (configMapRes.status == 200 && configMapRes.timings.duration) {
+      timingsArr["configmap"] = configMapRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("serviceaccount")) {
+    let serviceAccountRes = getLocalClusterServiceAccounts(baseUrl, cookies)
+    if (serviceAccountRes.status == 200 && serviceAccountRes.timings.duration) {
+      timingsArr["serviceaccount"] = serviceAccountRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("secret")) {
+    let secretRes = getLocalClusterSecrets(baseUrl, cookies)
+    if (secretRes.status == 200 && secretRes.timings.duration) {
+      timingsArr["secret"] = secretRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("pod")) {
+    let podRes = getLocalClusterPods(baseUrl, cookies)
+    if (podRes.status == 200 && podRes.timings.duration) {
+      timingsArr["pod"] = podRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("management.cattle.io.rkek8sserviceoption")) {
+    let rkeK8sServiceOptionRes = getLocalClusterRKEK8sServiceOptions(baseUrl, cookies)
+    if (rkeK8sServiceOptionRes.status == 200 && rkeK8sServiceOptionRes.timings.duration) {
+      timingsArr["management.cattle.io.rkek8sserviceoption"] = rkeK8sServiceOptionRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("apiregistration.k8s.io.apiservice")) {
+    let apiServiceRes = getLocalClusterAPIServices(baseUrl, cookies)
+    if (apiServiceRes.status == 200 && apiServiceRes.timings.duration) {
+      timingsArr["apiregistration.k8s.io.apiservice"] = apiServiceRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("management.cattle.io.roletemplate")) {
+    let roleTemplateRes = getLocalClusterRoleTemplates(baseUrl, cookies)
+    if (roleTemplateRes.status == 200 && roleTemplateRes.timings.duration) {
+      timingsArr["management.cattle.io.roletemplate"] = roleTemplateRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("management.cattle.io.project")) {
+    let projectsRes = getLocalClusterProjects(baseUrl, cookies)
+    if (projectsRes.status == 200 && projectsRes.timings.duration) {
+      timingsArr["management.cattle.io.project"] = projectsRes.timings.duration
+    }
+  }
+
+  if (accessibleSchemas.includes("namespace")) {
+    let namespacesRes = getLocalClusterNamespaces(baseUrl, cookies)
+    if (namespacesRes.status == 200 && namespacesRes.timings.duration) {
+      timingsArr["namespace"] = namespacesRes.timings.duration
+    }
+  }
+
+  return timingsArr
+}

--- a/k6/rancher/rancher_rolebindings_utils.js
+++ b/k6/rancher/rancher_rolebindings_utils.js
@@ -1,0 +1,145 @@
+import { check, fail, sleep } from 'k6'
+import http from 'k6/http'
+
+export const userGlobalRoleId = "user"
+export const viewRancherMetricsGlobalRoleId = "view-rancher-metrics"
+export const viewProjectsClusterRoleId = "projects-view"
+export const viewCRTBsClusterRoleId = "clusterroletemplatebindings-view"
+export const viewClusterCatalogsClusterRoleId = "clustercatalogs-view"
+
+export function getClusterRoleTemplateBindings(baseUrl, cookies) {
+  const res = http.get(`${baseUrl}/v3/clusterroletemplatebindings`,
+    { cookies: cookies }
+  )
+  check(res, {
+    'GET /v3/clusterroletemplatebindings returns status 200': (r) => r.status === 201,
+  })
+  return JSON.parse(res.body)
+}
+
+export function createClusterRoleTemplateBinding(baseUrl, cookies, clusterId, roleTemplateId, userPrincipalId) {
+  const res = http.post(`${baseUrl}/v3/clusterroletemplatebindings`,
+    {
+      "type": "clusterroletemplatebinding",
+      "clusterId": clusterId,
+      "roleTemplateId": roleTemplateId,
+      "userPrincipalId": userPrincipalId
+    },
+    { cookies: cookies }
+  )
+  check(res, {
+    'GET /v3/clusterroletemplatebindings returns status 200': (r) => r.status === 201,
+  })
+  return res
+}
+
+export function deleteClusterRoleTemplateBinding(baseUrl, cookies, crtbId) {
+  const res = http.del(`${baseUrl}/v3/clusterroletemplatebindings/${crtbId}`,
+    { cookies: cookies }
+  )
+  check(res, {
+    'DELETE /v3/clusterroletemplatebindings returns status 200': (r) => r.status === 200 || r.status === 204,
+  })
+  return JSON.parse(res.body)
+}
+
+export function createGlobalRoleBinding(baseUrl, cookies) {
+  const res = http.post(`${baseUrl}/v1/management.cattle.io.globalrolebindings`,
+    { cookies: cookies }
+  )
+  check(res, {
+    'POST /v1/management.cattle.io.globalrolebindings returns status 200': (r) => r.status === 200 || r.status === 204,
+  })
+  return JSON.parse(res.body)
+}
+
+export function getGlobalRoleBindings(baseUrl, cookies) {
+  const res = http.get(`${baseUrl}/v1/management.cattle.io.globalrolebindings`,
+    { cookies: cookies }
+  )
+  check(res, {
+    'GET /v1/management.cattle.io.globalrolebindings returns status 200': (r) => r.status === 200 || r.status === 204,
+  })
+  return JSON.parse(res.body).data
+}
+
+export function deleteGlobalRoleBinding(baseUrl, cookies, id) {
+  const res = http.del(`${baseUrl}/v1/management.cattle.io.globalrolebindings/${id}`,
+    { cookies: cookies }
+  )
+  check(res, {
+    'DELETE /v1/management.cattle.io.globalrolebindings returns status 200': (r) => r.status === 200 || r.status === 204,
+  })
+  return JSON.parse(res.body)
+}
+
+export function addPermissionToUser(baseUrl, cookies, userId, globalRoleId) {
+  const res = http.post(
+    `${baseUrl}/v3/globalrolebindings`,
+    JSON.stringify({
+      "type": "globalRoleBinding",
+      "globalRoleId": globalRoleId,
+      "userId": userId
+    }),
+    { cookies: cookies }
+  )
+
+  sleep(0.1)
+  if (res.status != 201) {
+    console.log("CREATE globalRoleBinding failed:\n", JSON.stringify(res, null, 2))
+  }
+  check(res, {
+    'POST /v3/globalrolebindings returns status 201': (r) => r.status === 201 || r.status === 204,
+  })
+  return res
+}
+
+export function giveUserPermission(baseUrl, cookies, userId) {
+  const res = addPermissionToUser(baseUrl, cookies, userId, userGlobalRoleId)
+
+  sleep(0.1)
+  if (res.status != 201) {
+    console.log(`POST '${userGlobalRoleId}' GlobalRoleBinding failed:\n`, JSON.stringify(res, null, 2))
+  }
+  return JSON.parse(res.body)
+}
+
+export function giveViewMetricsPermission(baseUrl, cookies, userId) {
+  const res = addPermissionToUser(baseUrl, cookies, userId, viewRancherMetricsGlobalRoleId)
+
+  sleep(0.1)
+  if (res.status != 201) {
+    console.log(`POST '${viewRancherMetricsGlobalRoleId}' GlobalRoleBinding failed:\n`, JSON.stringify(res, null, 2))
+  }
+  return JSON.parse(res.body)
+}
+
+export function giveViewClusterProjectsPermission(baseUrl, cookies, clusterId, userPrincipalId) {
+  const res = createClusterRoleTemplateBinding(baseUrl, cookies, clusterId, viewProjectsClusterRoleId, userPrincipalId)
+
+  sleep(0.1)
+  if (res.status != 201) {
+    console.log(`POST '${viewProjectsClusterRoleId}' ClusterRoleTemplateBinding failed:\n`, JSON.stringify(res, null, 2))
+  }
+  return JSON.parse(res.body)
+}
+
+export function giveViewCRTBsPermission(baseUrl, cookies, clusterId, userPrincipalId) {
+  const res = createClusterRoleTemplateBinding(baseUrl, cookies, clusterId, viewCRTBsClusterRoleId, userPrincipalId)
+
+  sleep(0.1)
+  if (res.status != 201) {
+    console.log(`POST '${viewCRTBsClusterRoleId}' ClusterRoleTemplateBinding failed:\n`, JSON.stringify(res, null, 2))
+  }
+  return JSON.parse(res.body)
+}
+
+export function giveViewClusterCatalogsPermission(baseUrl, cookies, clusterId, userPrincipalId) {
+  const res = createClusterRoleTemplateBinding(baseUrl, cookies, clusterId, viewClusterCatalogsClusterRoleId, userPrincipalId)
+
+  sleep(0.1)
+  if (res.status != 201) {
+    console.log(`POST '${viewClusterCatalogsClusterRoleId}' ClusterRoleTemplateBinding failed:\n`, JSON.stringify(res, null, 2))
+  }
+  return JSON.parse(res.body)
+}

--- a/k6/rancher/rancher_users_utils.js
+++ b/k6/rancher/rancher_users_utils.js
@@ -1,18 +1,18 @@
 import { check, fail, sleep } from 'k6'
 import http from 'k6/http'
 
-export function getUserId(baseUrl, cookies) {
+export function getCurrentUserId(baseUrl, cookies) {
   let response = http.get(`${baseUrl}/v3/users?me=true`, {
       headers: {
           accept: 'application/json',
       },
-      cookies: {cookies},
+      cookies: cookies,
   })
   check(response, {
-      'reading user details was successful': (r) => r.status === 200,
+    'reading user details was successful': (r) => r.status === 200,
   })
   if (response.status !== 200) {
-      fail('could not query user details')
+    fail('could not query user details')
   }
 
   return JSON.parse(response.body).data[0].id
@@ -23,10 +23,10 @@ export function getUserPreferences(baseUrl, cookies) {
       headers: {
           accept: 'application/json',
       },
-      cookies: {cookies},
+      cookies: cookies,
   })
   check(response, {
-      'preferences can be queried': (r) => r.status === 200,
+    'preferences can be queried': (r) => r.status === 200,
   })
   return JSON.parse(response.body)["data"][0]
 }
@@ -40,22 +40,22 @@ export function setUserPreferences(baseUrl, cookies, userId, userPreferences) {
               accept: 'application/json',
               'content-type': 'application/json',
           },
-          cookies: {cookies},
+          cookies: cookies,
       }
   )
   check(response, {
-      'preferences can be set': (r) => r.status === 200,
+    'preferences can be set': (r) => r.status === 200,
   })
   return response;
 }
 
 export function getPrincipalIds(baseUrl, cookies) {
   const response = http.get(
-      `${baseUrl}/v1/management.cattle.io.users`,
-      {cookies: cookies}
+    `${baseUrl}/v1/management.cattle.io.users`,
+    { cookies: cookies }
   )
   if (response.status !== 200) {
-      fail('could not list users')
+    fail('could not list users')
   }
   const users = JSON.parse(response.body).data
   return users.filter(u => u["username"] != null).map(u => u["principalIds"][0])
@@ -63,87 +63,84 @@ export function getPrincipalIds(baseUrl, cookies) {
 
 export function getPrincipalById(baseUrl, cookies, id) {
   const response = http.get(
-      `${baseUrl}/v3/principals/${id}`,
-      {cookies: cookies}
+    `${baseUrl}/v3/principals/${id}`,
+    { cookies: cookies }
   )
   if (response.status !== 200) {
-      fail('could not get principal by ID')
+    fail('could not get principal by ID')
   }
   return JSON.parse(response.body).data[0]
 }
 
-export function getUsers(baseUrl, params = null) {
+export function getNormanUsers(baseUrl, params = null) {
   const response = http.get(`${baseUrl}/v3/users`, params);
   console.log("GET users status: ", response.status);
-  check(response, {'status is 200': (r) => r.status === 200,}) || fail('could not get list of users');
+  check(response, { 'status is 200': (r) => r.status === 200, }) || fail('could not get list of users');
   return JSON.parse(response.body)["data"];
 }
 
 export function getCurrentUserPrincipal(baseUrl, cookies) {
   const response = http.get(
-      `${baseUrl}/v3/principals?me=true`,
-      {cookies: cookies}
+    `${baseUrl}/v3/principals?me=true`,
+    { cookies: cookies }
   )
   if (response.status !== 200) {
-      fail('could not get current User\'s Principal')
+    fail('could not get current User\'s Principal')
   }
   return JSON.parse(response.body).data[0]
 }
 
-export function getCurrentUserId(baseUrl, cookies) {
-  const response = http.get(
-      `${baseUrl}/v3/users?me=true`,
-      {cookies: cookies}
-  )
-  if (response.status !== 200) {
-      fail('could not get my user')
-  }
-  return JSON.parse(response.body).data[0].id
-}
-
 export function getCurrentUserPrincipalId(baseUrl, cookies) {
   const response = http.get(
-      `${baseUrl}/v3/users?me=true`,
-      {cookies: cookies}
+    `${baseUrl}/v3/users?me=true`,
+    { cookies: cookies }
   )
   if (response.status !== 200) {
-      fail('could not get my user')
+    fail('could not get my user')
   }
   return JSON.parse(response.body).data[0].principalIds[0]
 }
 
 export function getClusterIds(baseUrl, cookies) {
   const response = http.get(
-      `${baseUrl}/v1/management.cattle.io.clusters`,
-      {cookies: cookies}
+    `${baseUrl}/v1/management.cattle.io.clusters`,
+    { cookies: cookies }
   )
   if (response.status !== 200) {
-      fail('could not list clusters')
+    fail('could not list clusters')
   }
   const clusters = JSON.parse(response.body).data
   return clusters.map(c => c["id"])
 }
 
-export function createUser(baseUrl, params = null, id) {
-    const res = http.post(`${baseUrl}/v3/users`,
-        JSON.stringify({
-            "type": "user",
-            "name": `Dartboard Test User ${id}`,
-            "description": `Dartboard Test User ${id}`,
-            "enabled": true,
-            "mustChangePassword": false,
-            "password": "useruseruser",
-            "username": `user-${id}`
-        }),
-        params
-    )
+export function createUser(baseUrl, params = null, suffix) {
+  const res = http.post(`${baseUrl}/v3/users`,
+    JSON.stringify({
+      "type": "user",
+      "name": `Dartboard Test User ${suffix}`,
+      "description": `Dartboard Test User ${suffix}`,
+      "enabled": true,
+      "mustChangePassword": false,
+      "password": "useruseruser",
+      "username": `user-${suffix}`
+    }),
+    params
+  )
 
-    sleep(0.1)
-    if (res.status != 201) {
-        console.log("CREATE user failed:\n", JSON.stringify(res, null, 2))
-    }
-    check(res, {
-        '/v3/users returns status 201': (r) => r.status === 201,
-    })
-    return JSON.parse(res.body)
+  sleep(0.1)
+  if (res.status != 201) {
+    console.log("CREATE user failed:\n", JSON.stringify(res, null, 2))
+  }
+  check(res, {
+    '/v3/users returns status 201': (r) => r.status === 201,
+  })
+  return JSON.parse(res.body)
+}
+
+export function deleteUser(baseUrl, cookies, userId) {
+  const res = http.del(`${baseUrl}/v3/users/${userId}`, { cookies: cookies })
+  check(res, {
+    'DELETE /v3/users returns status 200': (r) => r.status === 200 || r.status === 204,
+  })
+  return JSON.parse(res.body)
 }

--- a/k6/tests/k6_with_env.sh
+++ b/k6/tests/k6_with_env.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 env_file=${1:-"./.env"} # path to the source-able .env file containing relevant variables
-test_file=${2} # path to the k6 test file to run
-iters=${3:-1} # the number of iterations of the test to loop through
-delay=${4:-15} # the delay between iterations, in minutes
-address=${5:-"localhost:6565"} # the domain:PORT address to the API server https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/#address
+test_file=${2}          # path to the k6 test file to run
+getRancherLogs=${3:-"false"}   # whether or not to get rancher pod logs
+iters=${4:-1}                  # the number of iterations of the test to loop through
+delay=${5:-15}                 # the delay between iterations, in minutes
+address=${6:-"localhost:6565"} # the domain:PORT address to the API server https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/#address
 
 counter=1
 sleepDuration=$((delay * 60))
@@ -12,8 +13,11 @@ while [ ${counter} -le "${iters}" ]; do
   iterStart=$(date -u '+%FT%T%:z')
   echo "Started iteration at: ${iterStart}"
   # shellcheck disable=SC1090
-  source "${env_file}" && k6 run -a "${address}" --out json="${test_file%.js*}-output${counter}.json" "${test_file}"
-  kubectl -n cattle-system logs -l status.phase=Running -l app=rancher -c rancher --timestamps --since-time="${iterStart}" --tail=9999999 >"rancher_logs-test_${test_file%.js*}.txt"
+  source "${env_file}" && k6 run --summary-mode=full -a "${address}" --out json="${test_file%.js*}-output${counter}.json" "${test_file}"
+  if [ "${getRancherLogs}" = "true" ]; then
+    echo "${KUBECONFIG}"
+    kubectl -n cattle-system logs -l status.phase=Running -l app=rancher -c rancher --timestamps --since-time="${iterStart}" --tail=999999 >"rancher_logs-test_${test_file%.js*}.txt"
+  fi
   if [[ ${iters} -ge 2 ]]; then
     sleep ${sleepDuration}
   fi

--- a/k6/tests/load_projects_rbac.js
+++ b/k6/tests/load_projects_rbac.js
@@ -1,0 +1,562 @@
+import { check, fail, sleep } from 'k6';
+import http from 'k6/http'
+import { Trend, Counter } from 'k6/metrics';
+import * as k6Util from "../generic/k6_utils.js";
+import { getCookies, login, logout } from "../rancher/rancher_utils.js";
+import * as userUtil from "../rancher/rancher_users_utils.js"
+import * as bindingUtil from "../rancher/rancher_rolebindings_utils.js"
+import { vu as metaVU } from 'k6/execution'
+import * as projectUtil from "../projects/project_utils.js";
+import * as namespaceUtil from "../namespaces/namespace_utils.js";
+import * as diagnosticsUtil from "../rancher/rancher_diagnostics.js";
+import { retryUntilOneOf } from "../rancher/rancher_utils.js";
+
+const vus = Number(__ENV.VUS || 1)
+const projectCount = Number(__ENV.PROJECT_COUNT || 1000)
+const namespacesPerProject = Number(__ENV.NAMESPACE_COUNT || 2)
+const iterations = Number(__ENV.ITERATIONS || 1)
+const baseUrl = __ENV.BASE_URL
+const username = __ENV.USERNAME
+const password = __ENV.PASSWORD
+const token = __ENV.TOKEN
+const timingDiffThreshold = 500
+const namePrefix = "projects-test"
+export const timePolled = new Trend('time_polled', true);
+
+const standardUserName = "user-standard"
+
+// Counters for tracking progress
+const projectsCreated = new Counter('projects_created')
+const namespacesCreated = new Counter('namespaces_created')
+const expectedProjectsPerVU = projectCount
+const expectedNamespacesPerVU = expectedProjectsPerVU * namespacesPerProject
+
+// Global variables to track created resources
+let createdProjectIds = []
+let createdNamespaceIds = []
+
+export const options = {
+  scenarios: {
+    load: {
+      executor: 'per-vu-iterations',
+      exec: 'loadProjects',
+      vus: vus,
+      iterations: iterations,
+      maxDuration: '24h',
+    }
+  },
+  thresholds: {
+    http_req_failed: ['rate<=0.01'], // http errors should be less than 1%
+    http_req_duration: ['p(99)<=500'], // 95% of requests should be below 500ms
+    checks: ['rate>0.99'], // the rate of successful checks should be higher than 99%
+    [`time_polled{url:'/v1/management.cattle.io.projects'}`]: ['p(99) < 5000', 'avg < 2500'],
+    // API response time thresholds - baseline
+    [`api_systemimage_duration{phase:'baseline', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_event_duration{phase:'baseline', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_k8sevent_duration{phase:'baseline', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_settings_duration{phase:'baseline', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_clusterrole_duration{phase:'baseline', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_crd_duration{phase:'baseline', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_configmap_duration{phase:'baseline', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_secret_duration{phase:'baseline', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_pod_duration{phase:'baseline', user:'admin'}`]: ['avg<4000', 'p(95)<2000'],
+    [`api_project_duration{phase:'baseline', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_namespace_duration{phase:'baseline', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    // API response time thresholds - halfway
+    [`api_systemimage_duration{phase:'halfway', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_event_duration{phase:'halfway', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_k8sevent_duration{phase:'halfway', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_settings_duration{phase:'halfway', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_clusterrole_duration{phase:'halfway', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_crd_duration{phase:'halfway', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_configmap_duration{phase:'halfway', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_secret_duration{phase:'halfway', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_pod_duration{phase:'halfway', user:'admin'}`]: ['avg<4000', 'p(95)<2000'],
+    [`api_project_duration{phase:'halfway', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_namespace_duration{phase:'halfway', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    // API response time thresholds - final
+    [`api_systemimage_duration{phase:'final', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_event_duration{phase:'final', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_k8sevent_duration{phase:'final', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_settings_duration{phase:'final', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_clusterrole_duration{phase:'final', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_crd_duration{phase:'final', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_configmap_duration{phase:'final', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_secret_duration{phase:'final', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_pod_duration{phase:'final', user:'admin'}`]: ['avg<4000', 'p(95)<2000'],
+    [`api_project_duration{phase:'final', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_namespace_duration{phase:'final', user:'admin'}`]: ['avg<1000', 'p(95)<2000'],
+    // API response time thresholds - baseline
+    [`api_systemimage_duration{phase:'baseline', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_event_duration{phase:'baseline', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_k8sevent_duration{phase:'baseline', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_settings_duration{phase:'baseline', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_clusterrole_duration{phase:'baseline', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_crd_duration{phase:'baseline', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_configmap_duration{phase:'baseline', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_secret_duration{phase:'baseline', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_pod_duration{phase:'baseline', user:'user-standard'}`]: ['avg<4000', 'p(95)<2000'],
+    [`api_project_duration{phase:'baseline', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_namespace_duration{phase:'baseline', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    // API response time thresholds - halfway
+    [`api_systemimage_duration{phase:'halfway', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_event_duration{phase:'halfway', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_k8sevent_duration{phase:'halfway', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_settings_duration{phase:'halfway', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_clusterrole_duration{phase:'halfway', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_crd_duration{phase:'halfway', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_configmap_duration{phase:'halfway', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_secret_duration{phase:'halfway', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_pod_duration{phase:'halfway', user:'user-standard'}`]: ['avg<4000', 'p(95)<2000'],
+    [`api_project_duration{phase:'halfway', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_namespace_duration{phase:'halfway', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    // API response time thresholds - final
+    [`api_systemimage_duration{phase:'final', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_event_duration{phase:'final', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_k8sevent_duration{phase:'final', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_settings_duration{phase:'final', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_clusterrole_duration{phase:'final', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_crd_duration{phase:'final', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_configmap_duration{phase:'final', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_secret_duration{phase:'final', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_pod_duration{phase:'final', user:'user-standard'}`]: ['avg<4000', 'p(95)<2000'],
+    [`api_project_duration{phase:'final', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+    [`api_namespace_duration{phase:'final', user:'user-standard'}`]: ['avg<1000', 'p(95)<2000'],
+  },
+  setupTimeout: '30m',
+  teardownTimeout: '30m',
+  insecureSkipTLSVerify: true,
+  // httpDebug: 'full',
+}
+
+function cleanup(adminCookies, namePrefix) {
+  let deleteAllFailed = false
+
+  // Can't delete rolebindings here because this function is used in setup() and 
+  // we have no way to track which bindings were created in previous test runs at this point
+  // console.log(`Cleaning up created users and bindings`)
+  // let delRes = bindingUtil.deleteClusterRoleTemplateBinding(baseUrl, data.userCookies, data.userCRTBId)
+  // if (delRes.status !== 200 && delRes.status !== 204) deleteAllFailed = true
+  // sleep(0.5)
+
+  // delRes = bindingUtil.deleteGlobalRoleBinding(baseUrl, data.userCookies, data.userGRBId)
+  // if (delRes.status !== 200 && delRes.status !== 204) deleteAllFailed = true
+  // sleep(0.5)
+  // delRes = bindingUtil.deleteGlobalRoleBinding(baseUrl, data.userCookies, data.userMetricsGRBId)
+  // if (delRes.status !== 200 && delRes.status !== 204) deleteAllFailed = true
+  // sleep(0.5)
+
+  let normanUsers = userUtil.getNormanUsers(baseUrl, { cookies: adminCookies })
+  normanUsers.filter(r => r["description"].startsWith("Dartboard Test ")).forEach(r => {
+    let delRes = retryUntilOneOf([200, 204], 5, () => userUtil.deleteUser(baseUrl, adminCookies, r.id))
+    if (delRes.status !== 200 && delRes.status !== 204) deleteAllFailed = true
+    sleep(0.5)
+  })
+
+  console.log(`Cleaning up created namespaces and projects with prefix: '${namePrefix}'`)
+  let { __, namespaceArray } = namespaceUtil.getNamespacesMatchingName(baseUrl, adminCookies, namePrefix)
+  console.log(`Found ${namespaceArray.length} namespaces to clean up`)
+  namespaceArray.forEach(r => {
+    let delRes = retryUntilOneOf([200, 204], 5, () => namespaceUtil.deleteNamespace(baseUrl, adminCookies, r["id"]))
+    if (delRes.status !== 200 && delRes.status !== 204) deleteAllFailed = true
+    sleep(0.1)
+  })
+
+  sleep(2)
+
+  let { _, projectArray } = projectUtil.getNormanProjectsMatchingName(baseUrl, adminCookies, namePrefix)
+  console.log(`Found ${projectArray.length} projects to clean up`)
+  projectArray.forEach(r => {
+    let delRes = retryUntilOneOf([200, 204], 5, () => projectUtil.deleteNormanProject(baseUrl, adminCookies, r["id"]))
+    if (delRes.status !== 200 && delRes.status !== 204) deleteAllFailed = true
+    sleep(0.1)
+  })
+  return deleteAllFailed
+}
+
+export function setup() {
+  console.log(`Starting load test with ${projectCount} projects and ${namespacesPerProject} namespaces per project`)
+  var cookies = {}
+
+  let adminLoginRes = login(baseUrl, {}, username, password)
+
+  if (adminLoginRes.status !== 200) {
+    fail(`could not login to cluster as admin`)
+  }
+  cookies = getCookies(baseUrl)
+  console.log("ADMIN COOKIES: ", cookies)
+
+  sleep(2)
+
+  // delete leftovers, if any
+  let deleteAllFailed = cleanup(cookies, namePrefix)
+  if (deleteAllFailed) fail("Failed to delete all existing test projects during setup!")
+
+  console.log("Creating standard user with view-rancher-metrics permissions")
+  let userData = userUtil.createUser(baseUrl, { cookies: cookies }, "standard")
+  const userPrincipalId = userData.principalIds[0]
+  const userId = userData.id
+
+  let userGlobalRoleBindingData = bindingUtil.giveUserPermission(baseUrl, cookies, userId)
+  let viewMetricsGlobalRoleBindingData = bindingUtil.giveViewMetricsPermission(baseUrl, cookies, userId)
+  bindingUtil.giveViewClusterProjectsPermission(baseUrl, cookies, "local", userPrincipalId)
+  bindingUtil.giveViewClusterCatalogsPermission(baseUrl, cookies, "local", userPrincipalId)
+  bindingUtil.giveViewCRTBsPermission(baseUrl, cookies, "local", userPrincipalId)
+  let crtbData = JSON.parse(bindingUtil.createClusterRoleTemplateBinding(baseUrl, cookies, "local", "cluster-member", userPrincipalId).body)
+  const userGRBId = userGlobalRoleBindingData.id
+  const userMetricsGRBId = viewMetricsGlobalRoleBindingData.id
+  const userCRTBId = crtbData.id
+
+  console.log("Logging in with standard user")
+  let userLoginRes = login(baseUrl, {}, standardUserName, "useruseruser")
+  if (userLoginRes.status !== 200) {
+    fail(`could not login to cluster as standard user`)
+  }
+  // See https://grafana.com/docs/k6/latest/using-k6/cookies/ for cookie-handling logic
+  var userCookies = {}
+  userCookies = { "R_SESS": [userLoginRes.cookies.R_SESS[0].value] }
+  console.log("ADMIN COOKIES: ", cookies)
+  console.log("USER COOKIES: ", userCookies)
+
+  sleep(2)
+
+  // return data that remains constant throughout the test
+  return {
+    adminCookies: cookies,
+    adminPrincipalId: userUtil.getCurrentUserPrincipalId(baseUrl, cookies),
+    userCookies: userCookies,
+    userPrincipalId: userPrincipalId,
+    userId: userId,
+    userGRBId: userGRBId,
+    userMetricsGRBId: userMetricsGRBId,
+    userCRTBId: userCRTBId
+  }
+}
+
+// export function teardown(data) {
+//   cleanup(data, namePrefix)
+//   logout(baseUrl, data.userCookies)
+//   logout(baseUrl, data.adminCookies)
+// }
+
+function collectResourceCounts(cookies, phase) {
+  console.log(`Collecting resource counts for phase: ${phase}`)
+
+  let resourceCountsRaw = diagnosticsUtil.getLocalClusterResourceCounts(baseUrl, cookies)
+  let resourceCounts = diagnosticsUtil.processResourceCounts(resourceCountsRaw)
+
+  // Record key resource counts as metrics
+  if (resourceCounts.projects && resourceCounts.projects.totalCount !== undefined) {
+    diagnosticsUtil.totalProjectsGauge.add(resourceCounts.projects.totalCount, { phase: phase })
+    console.log(`${phase} - Total Projects: ${resourceCounts.projects.totalCount}`)
+  }
+
+  if (resourceCounts.namespaces && resourceCounts.namespaces.totalCount !== undefined) {
+    diagnosticsUtil.totalNamespacesGauge.add(resourceCounts.namespaces.totalCount, { phase: phase })
+    console.log(`${phase} - Total Namespaces: ${resourceCounts.namespaces.totalCount}`)
+  }
+
+  if (resourceCounts.pods && resourceCounts.pods.totalCount !== undefined) {
+    diagnosticsUtil.totalPodsGauge.add(resourceCounts.pods.totalCount, { phase: phase })
+    console.log(`${phase} - Total Pods: ${resourceCounts.pods.totalCount}`)
+  }
+
+  if (resourceCounts.secrets && resourceCounts.secrets.totalCount !== undefined) {
+    diagnosticsUtil.totalSecretsGauge.add(resourceCounts.secrets.totalCount, { phase: phase })
+    console.log(`${phase} - Total Secrets: ${resourceCounts.secrets.totalCount}`)
+  }
+
+  if (resourceCounts.configmaps && resourceCounts.configmaps.totalCount !== undefined) {
+    diagnosticsUtil.totalConfigMapsGauge.add(resourceCounts.configmaps.totalCount, { phase: phase })
+    console.log(`${phase} - Total ConfigMaps: ${resourceCounts.configmaps.totalCount}`)
+  }
+
+  if (resourceCounts.serviceaccounts && resourceCounts.serviceaccounts.totalCount !== undefined) {
+    diagnosticsUtil.totalServiceAccountsGauge.add(resourceCounts.serviceaccounts.totalCount, { phase: phase })
+    console.log(`${phase} - Total ServiceAccounts: ${resourceCounts.serviceaccounts.totalCount}`)
+  }
+
+  if (resourceCounts.clusterroles && resourceCounts.clusterroles.totalCount !== undefined) {
+    diagnosticsUtil.totalClusterRolesGauge.add(resourceCounts.clusterroles.totalCount, { phase: phase })
+    console.log(`${phase} - Total ClusterRoles: ${resourceCounts.clusterroles.totalCount}`)
+  }
+
+  if (resourceCounts.customresourcedefinitions && resourceCounts.customresourcedefinitions.totalCount !== undefined) {
+    diagnosticsUtil.totalCRDsGauge.add(resourceCounts.customresourcedefinitions.totalCount, { phase: phase })
+    console.log(`${phase} - Total CRDs: ${resourceCounts.customresourcedefinitions.totalCount}`)
+  }
+
+  return resourceCounts
+}
+
+function collectAPITimings(cookies, phase, user) {
+  console.log(`Collecting API response timings for phase: ${phase} user: ${user}`)
+  let timings = diagnosticsUtil.processResourceTimings(baseUrl, cookies)
+
+  // Record each API timing with phase and user tags
+  const timingsTags = { phase: phase, user: user }
+
+  if (timings["management.cattle.io.rkek8ssystemimage"]) {
+    diagnosticsUtil.systemImageAPITime.add(timings["management.cattle.io.rkek8ssystemimage"], timingsTags)
+  }
+
+  if (timings["event"]) {
+    diagnosticsUtil.eventAPITime.add(timings["event"], timingsTags)
+  }
+
+  if (timings["events.k8s.io.event"]) {
+    diagnosticsUtil.k8sEventAPITime.add(timings["events.k8s.io.event"], timingsTags)
+  }
+
+  if (timings["management.cattle.io.setting"]) {
+    diagnosticsUtil.settingsAPITime.add(timings["management.cattle.io.setting"], timingsTags)
+  }
+
+  if (timings["rbac.authorization.k8s.io.clusterrole"]) {
+    diagnosticsUtil.clusterRoleAPITime.add(timings["rbac.authorization.k8s.io.clusterrole"], timingsTags)
+  }
+
+  if (timings["apiextensions.k8s.io.customresourcedefinition"]) {
+    diagnosticsUtil.crdAPITime.add(timings["apiextensions.k8s.io.customresourcedefinition"], timingsTags)
+  }
+
+  if (timings["rbac.authorization.k8s.io.role"]) {
+    diagnosticsUtil.roleAPITime.add(timings["rbac.authorization.k8s.io.role"], timingsTags)
+  }
+
+  if (timings["rbac.authorization.k8s.io.rolebinding"]) {
+    diagnosticsUtil.roleBindingAPITime.add(timings["rbac.authorization.k8s.io.rolebinding"], timingsTags)
+  }
+
+  if (timings["rbac.authorization.k8s.io.clusterrolebinding"]) {
+    diagnosticsUtil.clusterRoleBindingAPITime.add(timings["rbac.authorization.k8s.io.clusterrolebinding"], timingsTags)
+  }
+
+  if (timings["management.cattle.io.globalrolebinding"]) {
+    diagnosticsUtil.globalRoleBindingAPITime.add(timings["management.cattle.io.globalrolebinding"], timingsTags)
+  }
+
+  if (timings["management.cattle.io.rkeaddon"]) {
+    diagnosticsUtil.rkeAddonAPITime.add(timings["management.cattle.io.rkeaddon"], timingsTags)
+  }
+
+  if (timings["configmap"]) {
+    diagnosticsUtil.configMapAPITime.add(timings["configmap"], timingsTags)
+  }
+
+  if (timings["serviceaccount"]) {
+    diagnosticsUtil.serviceAccountAPITime.add(timings["serviceaccount"], timingsTags)
+  }
+
+  if (timings["secret"]) {
+    diagnosticsUtil.secretAPITime.add(timings["secret"], timingsTags)
+  }
+
+  if (timings["pod"]) {
+    diagnosticsUtil.podAPITime.add(timings["pod"], timingsTags)
+  }
+
+  if (timings["management.cattle.io.rkek8sserviceoption"]) {
+    diagnosticsUtil.rkeServiceOptionAPITime.add(timings["management.cattle.io.rkek8sserviceoption"], timingsTags)
+  }
+
+  if (timings["apiregistration.k8s.io.apiservice"]) {
+    diagnosticsUtil.apiServiceAPITime.add(timings["apiregistration.k8s.io.apiservice"], timingsTags)
+  }
+
+  if (timings["management.cattle.io.roletemplate"]) {
+    diagnosticsUtil.roleTemplateAPITime.add(timings["management.cattle.io.roletemplate"], timingsTags)
+  }
+
+  if (timings["management.cattle.io.project"]) {
+    diagnosticsUtil.projectAPITime.add(timings["management.cattle.io.project"], timingsTags)
+  }
+
+  if (timings["namespace"]) {
+    diagnosticsUtil.namespaceAPITime.add(timings["namespace"], timingsTags)
+  }
+
+  let slowestApis = Object.entries(timings)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+
+  console.log(`${phase} - Top 5 slowest APIs:`)
+  slowestApis.forEach(([api, time], index) => {
+    console.log(`  ${index + 1}. ${api}: ${time.toFixed(2)}ms`)
+  })
+
+  return timings
+}
+
+function getProjectWithRetry(baseUrl, cookies, projectId, maxRetries = 5) {
+  for (let retry = 0; retry < maxRetries; retry++) {
+    let { res, project } = projectUtil.getProject(baseUrl, cookies, projectId)
+    if (res.status == 200 && project && project.status.conditions) {
+      return project
+    }
+    console.warn(`GET Project attempt #${retry + 1} failed with status ${res.status}`)
+    sleep(1)
+  }
+  return {}
+}
+
+function createNormanProjectWithRetry(baseUrl, projectBody, cookies, maxRetries = 5) {
+  for (let retry = 0; retry < maxRetries; retry++) {
+    const res = projectUtil.createNormanProject(baseUrl, projectBody, cookies)
+    if (res.status === 201) {
+      return res
+    }
+    console.warn(`POST Project attempt #${retry + 1} failed with status ${res.status}`)
+    sleep(1)
+  }
+  return {}
+}
+
+function createProjectsAndNamespaces(data, startIndex, endIndex) {
+  console.log(`Creating projects from ${startIndex} to ${endIndex}`)
+  console.debug("CURRENT USER PRINCIPAL ID: ", data.adminPrincipalId)
+
+  for (let i = startIndex; i < endIndex; i++) {
+    const projectName = `${namePrefix}-${metaVU.idInInstance}-${i.toString().padStart(4, '0')}`
+    const projectBody = JSON.stringify({
+      type: "project",
+      name: projectName,
+      description: `Load test project ${i + 1}`,
+      clusterId: "local",
+      creatorId: data.adminPrincipalId,
+      labels: {},
+      annotations: {},
+      resourceQuota: {},
+      containerDefaultResourceLimit: {},
+      namespaceDefaultResourceQuota: {}
+    })
+
+    console.log(`Creating project ${i + 1}/${projectCount}: ${projectName}`)
+    const projectRes = createNormanProjectWithRetry(baseUrl, projectBody, data.adminCookies, 5)
+
+    if (projectRes.status === 201) {
+      const projectData = JSON.parse(projectRes.body)
+      createdProjectIds.push(projectData.id)
+      projectsCreated.add(1)
+      let projectId = projectData.id.replace(":", "/")
+      let steveProject = getProjectWithRetry(baseUrl, data.adminCookies, projectId, 5)
+
+      // Create namespaces for this project
+      for (let j = 0; j < namespacesPerProject; j++) {
+        const namespaceName = `${namePrefix}-${metaVU.idInInstance}ns-${i.toString().padStart(4, '0')}-${j + 1}`
+        const namespaceBody = JSON.stringify({
+          "type": "namespace",
+          "disableOpenApiValidation": false,
+          "metadata": {
+            "name": namespaceName,
+            "labels": {
+              "field.cattle.io/projectId": steveProject.metadata.name
+            },
+            "annotations": {
+              "field.cattle.io/containerDefaultResourceLimit": "{}",
+              "field.cattle.io/description": `Load test namespace ${i + j + 1}`,
+              "field.cattle.io/projectId": projectData.id
+            },
+          },
+        })
+
+        console.log(`  Creating namespace ${j + 1}/${namespacesPerProject}: ${namespaceName}`)
+        const namespaceRes = namespaceUtil.createNamespace(baseUrl, namespaceBody, data.adminCookies)
+
+        if (namespaceRes.status === 201) {
+          const namespaceData = JSON.parse(namespaceRes.body)
+          createdNamespaceIds.push(namespaceData.id)
+          namespacesCreated.add(1)
+        } else {
+          console.error(`Failed to create namespace ${namespaceName}: ${namespaceRes.status}`)
+        }
+
+        sleep(0.5)
+      }
+    } else {
+      console.error(`Failed to create project ${projectName}: ${projectRes.status}`)
+    }
+
+    if ((i + 1) % 50 === 0) {
+      console.log(`Progress: ${i + 1}/${endIndex} projects created`)
+    }
+
+    sleep(0.5)
+  }
+}
+
+export function loadProjects(data) {
+  console.log("=== Starting Load Test Execution ===")
+
+  // Step 1: Baseline measurement (before creating any projects)
+  console.log('Step 1: Collecting initial diagnostics...')
+  let resourceCounts = collectResourceCounts(data.adminCookies, 'baseline')
+  diagnosticsUtil.processMetricsFromCountData(resourceCounts)
+  let adminTimings = collectAPITimings(data.adminCookies, 'baseline', 'admin')
+  sleep(5)
+  let userTimings = collectAPITimings(data.userCookies, 'baseline', standardUserName)
+  Object.keys(adminTimings).forEach(key => {
+    if (userTimings.hasOwnProperty(key)) {
+      let adminValue = adminTimings[key]
+      let userValue = userTimings[key]
+      let threshold = userValue + timingDiffThreshold
+
+      let checkName = `API Response Timing comparison for ${key}`
+      let passed = adminValue <= threshold
+
+      check(null, {
+        [checkName]: () => passed,
+      })
+      if (!passed) {
+        console.warn(`Timing Diff surpassed threshold for ${key}:`)
+        console.warn(`   Admin: ${adminValue}ms, User: ${userValue}ms`)
+        console.warn(`   Diff: +${adminValue - userValue}ms (threshold: ${timingDiffThreshold}ms)`)
+      } else {
+        console.log(`${key}: ${adminValue}ms (User: ${userValue}ms, Diff: ${adminValue - userValue > 0 ? '+' : ''}${adminValue - userValue}ms)`)
+      }
+    } else {
+      console.info(`New metric found: ${key} = ${adminTimings[key]}ms (no equivalent metric for the given non-admin user is available)`)
+    }
+  })
+
+  // Step 2: Create first half of projects
+  const halfwayPoint = Math.floor(projectCount / 2)
+  console.log(`Step 2: Creating first half of projects (0 to ${halfwayPoint})...`)
+  createProjectsAndNamespaces(data, 0, halfwayPoint)
+
+  // Step 3: Halfway measurement
+  console.log('Step 3: Collecting diagnostics at halfway point...')
+  resourceCounts = collectResourceCounts(data.adminCookies, 'halfway')
+  diagnosticsUtil.processMetricsFromCountData(resourceCounts)
+  collectAPITimings(data.adminCookies, 'halfway', 'admin')
+  sleep(5)
+  collectAPITimings(data.userCookies, 'halfway', standardUserName)
+
+  // Step 4: Create remaining projects
+  console.log(`Step 4: Creating remaining projects (${halfwayPoint} to ${projectCount})...`)
+  createProjectsAndNamespaces(data, halfwayPoint, projectCount)
+
+  // Step 5: Final measurement
+  console.log('Step 5: Collecting final diagnostics...')
+  resourceCounts = collectResourceCounts(data.adminCookies, 'final')
+  diagnosticsUtil.processMetricsFromCountData(resourceCounts)
+  collectAPITimings(data.adminCookies, 'final', 'admin')
+  sleep(5)
+  collectAPITimings(data.userCookies, 'final', standardUserName)
+
+  let projectCriteria = []
+  let numProjects = createdProjectIds.length
+  let numNamespaces = createdNamespaceIds.length
+  projectCriteria[`expected # of projects (${expectedProjectsPerVU}) were created`] = (p) => p === expectedProjectsPerVU
+  check(numProjects, projectCriteria)
+  let namespaceCriteria = []
+  namespaceCriteria[`expected # of namespaces (${expectedNamespacesPerVU}) were created`] = (n) => n === expectedNamespacesPerVU
+  check(numNamespaces, namespaceCriteria)
+
+  console.log("=== Load Test Execution Complete ===")
+  console.log(`Total projects created: ${numProjects}`)
+  console.log(`Total namespaces created: ${numNamespaces}`)
+  console.log(`  Expected total: ${expectedProjectsPerVU} projects, ${expectedNamespacesPerVU} namespaces`)
+  console.log("=== Final Resource Counts ===")
+  console.log(JSON.stringify(resourceCounts, null, 2))
+}


### PR DESCRIPTION
**NOTE:** This PR was mistakenly opened out of order, please review PR #85 first
- Adds various utils for:
  - namespaces
  - projects
  - rolebindings
  - users
  - general rancher utils
- Adds robust metrics tracking support for the APIs tracked on the `rancher/diagnostics` page

The `load_projects_rbac.js` script was used for the testing of https://github.com/rancher/rancher/issues/50484 and its backports

Resolves https://github.com/rancher/dartboard/issues/52
Resolves https://github.com/rancher/dartboard/issues/75