### PR TITLE
API benchmark: add optional pauses between requests

### DIFF
--- a/k6/tests/api_benchmark.js
+++ b/k6/tests/api_benchmark.js
@@ -3,7 +3,7 @@ import http from 'k6/http';
 
 // Parameters
 const vus = __ENV.VUS || 1
-const perVuIterations = __ENV.PER_VU_ITERATIONS || 30
+const perVuIterations = parseInt(__ENV.PER_VU_ITERATIONS || 30)
 const baseUrl = __ENV.BASE_URL
 const username = __ENV.USERNAME
 const password = __ENV.PASSWORD
@@ -12,10 +12,10 @@ const cluster = __ENV.CLUSTER || "local"
 const resource = __ENV.RESOURCE || "management.cattle.io.setting"
 const api = __ENV.API || "steve"
 const paginationStyle = __ENV.PAGINATION_STYLE || "k8s"
-const pageSize = __ENV.PAGE_SIZE || 100
+const pageSize = parseInt(__ENV.PAGE_SIZE || 100)
 const firstPageOnly = __ENV.FIRST_PAGE_ONLY === "true"
 const urlSuffix = __ENV.URL_SUFFIX || ""
-const pauseSeconds = __ENV.PAUSE_SECONDS || 0
+const pauseSeconds = parseFloat(__ENV.PAUSE_SECONDS || 0.0)
 
 // Option setting
 export const options = {


### PR DESCRIPTION
In order to test conditions as specified in the [Rancher Perfomance PD&O](https://confluence.suse.com/pages/viewpage.action?pageId=1244103507), this adds a pausing mechanism to simulate real users.

(better ways exist, specifically using Ramping arrival rate, but they are more complex as here every list loops through a potentially very long set of requests, so starting simple here).

Use via:

  - `-e PAUSE_SECONDS=5`: add an average pause of 5 seconds after each request (simulated click)

