### PR TITLE
Fix broken `dartboard load` command

### DIFF
--- a/charts/k6-files/.helmignore
+++ b/charts/k6-files/.helmignore
@@ -1,0 +1,14 @@
+*.json
+*.txt
+*.csv
+*.md
+*.log
+*.png
+*.jpg
+*.jpeg
+*.webp
+*.gif
+*.mp4
+*.wav
+README*
+.DS_Store

--- a/charts/k6-files/templates/configmap.yaml
+++ b/charts/k6-files/templates/configmap.yaml
@@ -1,13 +1,13 @@
+{{- $files := .Files }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: k6-test-files
 data:
-{{ (.Files.Glob "test-files/**.{js,mjs}").AsConfig | indent 2 }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k6-lib-files
-data:
-{{ (.Files.Glob "test-files/lib/*.{js,mjs}").AsConfig | indent 2 }}
+{{- range $path, $_ := .Files.Glob "test-files/**.{js,mjs,ts}" }}
+  {{- if $path }}
+  {{- $key := (trimPrefix "test-files/" $path) | replace "/" "__" }}
+  {{ $key }}: |-
+{{ $files.Get $path | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/cmd/dartboard/subcommands/deploy.go
+++ b/cmd/dartboard/subcommands/deploy.go
@@ -573,7 +573,7 @@ func importDownstreamClustersRancherSetup(r *dart.Dart, clusters map[string]tofu
 		"IMPORTED_CLUSTER_NAMES": importedClusterNames,
 	}
 
-	if err = kubectl.K6run(tester.Kubeconfig, "k6/rancher_setup.js", envVars, nil, true, upstreamAdd.Local.HTTPSURL, false); err != nil {
+	if err = kubectl.K6run(tester.Kubeconfig, "rancher/rancher_setup.js", envVars, nil, true, upstreamAdd.Local.HTTPSURL, false); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/dartboard/subcommands/load.go
+++ b/cmd/dartboard/subcommands/load.go
@@ -70,7 +70,7 @@ func Load(cli *cli.Context) error {
 	return nil
 }
 
-func loadConfigMapAndSecrets(r *dart.Dart, kubecongfig string, clusterName string, clusterData tofu.Cluster) error {
+func loadConfigMapAndSecrets(r *dart.Dart, kubeconfig string, clusterName string, clusterData tofu.Cluster) error {
 	configMapCount := strconv.Itoa(r.TestVariables.TestConfigMaps)
 	secretCount := strconv.Itoa(r.TestVariables.TestSecrets)
 
@@ -89,7 +89,7 @@ func loadConfigMapAndSecrets(r *dart.Dart, kubecongfig string, clusterName strin
 	}
 
 	log.Printf("Load resources on cluster %q (#ConfigMaps: %s, #Secrets: %s)\n", clusterName, configMapCount, secretCount)
-	if err := kubectl.K6run(kubecongfig, "create_k8s_resources.js", envVars, tags, true, clusterData.KubernetesAddresses.Tunnel, false); err != nil {
+	if err := kubectl.K6run(kubeconfig, "generic/create_k8s_resources.js", envVars, tags, true, clusterData.KubernetesAddresses.Tunnel, false); err != nil {
 		return fmt.Errorf("failed loading ConfigMaps and Secrets on cluster %q: %w", clusterName, err)
 	}
 	return nil
@@ -118,7 +118,7 @@ func loadRolesAndUsers(r *dart.Dart, kubeconfig string, clusterName string, clus
 
 	log.Printf("Load resources on cluster %q (#Roles: %s, #Users: %s)\n", clusterName, roleCount, userCount)
 
-	if err := kubectl.K6run(kubeconfig, "create_roles_users.js", envVars, tags, true, clusterAdd.Local.HTTPSURL, false); err != nil {
+	if err := kubectl.K6run(kubeconfig, "generic/create_roles_users.js", envVars, tags, true, clusterAdd.Local.HTTPSURL, false); err != nil {
 		return fmt.Errorf("failed loading Roles and Users on cluster %q: %w", clusterName, err)
 	}
 	return nil
@@ -144,7 +144,7 @@ func loadProjects(r *dart.Dart, kubeconfig string, clusterName string, clusterDa
 
 	log.Printf("Load resources on cluster %q (#Projects: %s)\n", clusterName, projectCount)
 
-	if err := kubectl.K6run(kubeconfig, "create_projects.js", envVars, tags, true, clusterAdd.Local.HTTPSURL, false); err != nil {
+	if err := kubectl.K6run(kubeconfig, "generic/create_projects.js", envVars, tags, true, clusterAdd.Local.HTTPSURL, false); err != nil {
 		return fmt.Errorf("failed loading Projects on cluster %q: %w", clusterName, err)
 	}
 	return nil

--- a/cmd/dartboard/subcommands/load.go
+++ b/cmd/dartboard/subcommands/load.go
@@ -28,7 +28,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// TODO: Make this command idempotent. Get count (# of resources) matching some unique identifer.
+// TODO: Make this command idempotent. Get count (# of resources) matching some unique identifier.
 // Then rerun the appropriate script, passing in the index to leave off on.
 // * Scripts need to support this type of idempotency, they currently do not
 func Load(cli *cli.Context) error {

--- a/cmd/dartboard/subcommands/load.go
+++ b/cmd/dartboard/subcommands/load.go
@@ -28,6 +28,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// TODO: Make this command idempotent. Get count (# of resources) matching some unique identifer.
+// Then rerun the appropriate script, passing in the index to leave off on.
+// * Scripts need to support this type of idempotency, they currently do not
 func Load(cli *cli.Context) error {
 	tf, r, err := prepare(cli)
 	if err != nil {
@@ -86,7 +89,7 @@ func loadConfigMapAndSecrets(r *dart.Dart, kubecongfig string, clusterName strin
 	}
 
 	log.Printf("Load resources on cluster %q (#ConfigMaps: %s, #Secrets: %s)\n", clusterName, configMapCount, secretCount)
-	if err := kubectl.K6run(kubecongfig, "k6/create_k8s_resources.js", envVars, tags, true, clusterData.KubernetesAddresses.Tunnel, false); err != nil {
+	if err := kubectl.K6run(kubecongfig, "create_k8s_resources.js", envVars, tags, true, clusterData.KubernetesAddresses.Tunnel, false); err != nil {
 		return fmt.Errorf("failed loading ConfigMaps and Secrets on cluster %q: %w", clusterName, err)
 	}
 	return nil
@@ -115,7 +118,7 @@ func loadRolesAndUsers(r *dart.Dart, kubeconfig string, clusterName string, clus
 
 	log.Printf("Load resources on cluster %q (#Roles: %s, #Users: %s)\n", clusterName, roleCount, userCount)
 
-	if err := kubectl.K6run(kubeconfig, "k6/create_roles_users.js", envVars, tags, true, clusterAdd.Local.HTTPSURL, false); err != nil {
+	if err := kubectl.K6run(kubeconfig, "create_roles_users.js", envVars, tags, true, clusterAdd.Local.HTTPSURL, false); err != nil {
 		return fmt.Errorf("failed loading Roles and Users on cluster %q: %w", clusterName, err)
 	}
 	return nil
@@ -141,7 +144,7 @@ func loadProjects(r *dart.Dart, kubeconfig string, clusterName string, clusterDa
 
 	log.Printf("Load resources on cluster %q (#Projects: %s)\n", clusterName, projectCount)
 
-	if err := kubectl.K6run(kubeconfig, "k6/create_projects.js", envVars, tags, true, clusterAdd.Local.HTTPSURL, false); err != nil {
+	if err := kubectl.K6run(kubeconfig, "create_projects.js", envVars, tags, true, clusterAdd.Local.HTTPSURL, false); err != nil {
 		return fmt.Errorf("failed loading Projects on cluster %q: %w", clusterName, err)
 	}
 	return nil

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -308,11 +308,9 @@ func K6run(kubeconfig, testPath string, envVars, tags map[string]string, printLo
 	// get rel path to test file
 	for _, e := range entries {
 		if strings.Contains(e.RelPath, testPath) {
-			log.Printf("FOUND RELATIVE FILE PATH: %s\n", e.RelPath)
 			relTestPath = e.RelPath
 			break
 		}
-		log.Printf("SEARCHING FOR FILE: %s\n", testPath)
 	}
 
 	// print what we are about to do

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -149,8 +149,6 @@ func collectFileEntries(root string, exts map[string]bool) ([]FileEntry, error) 
 					stack = append(stack, stackEntry{virtualRel: virtualRel, realPath: target})
 					continue
 				}
-				// else its a file symlink, treat as file using resolved target path
-				entryRealPath = target
 			} else {
 				if de.IsDir() {
 					stack = append(stack, stackEntry{virtualRel: virtualRel, realPath: entryRealPath})

--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -128,20 +128,20 @@ func collectFileEntries(root string, exts map[string]bool) ([]FileEntry, error) 
 					entries = append(entries, FileEntry{RelPath: finalRel, Key: key})
 					return nil
 				})
-			} else {
-				// It's a file symlink, treat it as a regular file
-				ext := filepath.Ext(resolvedPath)
-				if !exts[ext] {
-					return nil
-				}
-
-				rel, err := filepath.Rel(root, path)
-				if err != nil {
-					return err
-				}
-				key := strings.ReplaceAll(rel, string(os.PathSeparator), "__")
-				entries = append(entries, FileEntry{RelPath: rel, Key: key})
 			}
+			// Else, it's a file symlink, treat it as a regular file
+			ext := filepath.Ext(resolvedPath)
+			if !exts[ext] {
+				return nil
+			}
+
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			key := strings.ReplaceAll(rel, string(os.PathSeparator), "__")
+			entries = append(entries, FileEntry{RelPath: rel, Key: key})
+
 			return nil
 		}
 


### PR DESCRIPTION
- modifies configmap.yaml template to account for new k6/ dir structure
- modifies load.go to account for new k6/ dir structure
- adds a TODO to load.go
- modifies internal/kubectl.go's k6Run() function to account for the new dir structure
- adds a `.helmignore` file to the k6-files chart to mitigate data size issues when uploading files to tester cluster

Closes: #96 