### PR TITLE
feat(k6): Add Steve Watch API benchmark test

### DIFF
--- a/k6/tests/steve_watch_benchmark.js
+++ b/k6/tests/steve_watch_benchmark.js
@@ -130,6 +130,12 @@ export async function watchScenario(data) {
 
         ws.addEventListener('open', () => {
             console.log(`Connected to ${url}`);
+
+            setTimeout(() => {
+                console.log(`Closing socket to ${url}`);
+                ws.close();
+            }, watchDuration * 1000);
+
             ws.send(JSON.stringify({
                 resourceType: resource,
                 namespace: namespace,
@@ -170,15 +176,10 @@ export async function watchScenario(data) {
 
         ws.addEventListener('close', () => console.log(`disconnected from ${url}`));
         ws.addEventListener('error', (e) => {
-            if (e.error() != 'websocket: close sent') {
-                console.log('An unexpected error occured: ', e.error());
+            if (e.error != 'websocket: close sent') {
+                console.log('An unexpected error occured: ', e.error);
             }
         });
-
-        ws.setTimeout(() => {
-            console.log(`Closing socket to ${url}`);
-            ws.close();
-        }, watchDuration * 1000);
     }
 
     console.log("Done watching");

--- a/k6/tests/steve_watch_benchmark.js
+++ b/k6/tests/steve_watch_benchmark.js
@@ -1,0 +1,195 @@
+
+import { check, fail, sleep } from 'k6';
+import http from 'k6/http';
+import { Trend } from 'k6/metrics';
+import ws from 'k6/ws';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
+
+// Parameters
+const steveServers = (__ENV.STEVE_SERVERS || 'http://localhost:8080').split(',');
+const namespace = __ENV.NAMESPACE || 'scalability-tests';
+const resource = __ENV.RESOURCE || 'configmaps';
+const changeRate = __ENV.CHANGE_RATE || 1;
+const watchMode = __ENV.WATCH_MODE || ''; // "" for full resource, "resource.changes" for notifications
+const numConfigMaps = __ENV.CONFIG_MAP_COUNT || 100;
+const vus = __ENV.K6_VUS || 1;
+const iterations = __ENV.PER_VU_ITERATIONS || 10;
+
+const username = __ENV.USERNAME;
+const password = __ENV.PASSWORD;
+const token = __ENV.TOKEN;
+
+
+// Metrics
+const deltaFastestSlowest = new Trend('delta_fastest_slowest', true);
+const delayFirstObserver = new Trend('delay_first_observer', true);
+const delayLastObserver = new Trend('delay_last_observer', true);
+
+export const options = {
+    insecureSkipTLSVerify: true,
+    scenarios: {
+        watch: {
+            executor: 'per-vu-iterations',
+            exec: 'watchScenario',
+            vus: vus,
+            iterations: iterations,
+            maxDuration: '24h',
+        },
+        change: {
+            executor: 'constant-arrival-rate',
+            exec: 'changeScenario',
+            rate: changeRate,
+            timeUnit: '1s',
+            duration: '24h',
+            preAllocatedVUs: 1,
+        },
+    },
+    thresholds: {
+        checks: ['rate>0.99'],
+        http_req_failed: ['rate<0.01'],
+        http_req_duration: ['p(95)<500'],
+    },
+};
+
+export function setup() {
+    var cookies = {}
+    if (token) {
+        cookies = {R_SESS: token}
+    }
+    else if (username && password) {
+        const res = http.post(`${steveServers[0]}/v3-public/localProviders/local?action=login`, JSON.stringify({
+            "description": "UI session",
+            "responseType": "cookie",
+            "username": username,
+            "password": password
+        }))
+
+        check(res, {
+            'logging in returns status 200': (r) => r.status === 200,
+        })
+
+        cookies = http.cookieJar().cookiesForURL(res.url)
+    }
+    else {
+        fail("Please specify either USERNAME and PASSWORD or TOKEN")
+    }
+
+    // Create namespace
+    const nsBody = {
+        "type": "namespace",
+        "metadata": {
+            "name": namespace,
+        },
+    }
+    let res = http.post(`${steveServers[0]}/v1/namespaces`, JSON.stringify(nsBody), { cookies: cookies, headers: { "Content-Type": "application/json" } })
+    check(res, {
+        'create namespace returns 201': (r) => r.status === 201,
+    })
+
+    // Create configmaps
+    for (let i = 0; i < numConfigMaps; i++) {
+        const name = `test-config-map-${i}`
+        const cmBody = {
+            "type": "configmap",
+            "metadata": {
+                "name": name,
+                "namespace": namespace
+            },
+            "data": {"data": "initial"}
+        }
+        res = http.post(`${steveServers[0]}/v1/configmaps`, JSON.stringify(cmBody), { cookies: cookies, headers: { "Content-Type": "application/json" } })
+        check(res, {
+            'create configmap returns 201': (r) => r.status === 201,
+        })
+    }
+
+    return { cookies: cookies };
+}
+
+export function teardown(data) {
+    http.del(`${steveServers[0]}/v1/namespaces/${namespace}`, null, { cookies: data.cookies })
+}
+
+let lastChangeTime = null;
+let changeEvents = {};
+
+export function watchScenario(data) {
+    const sockets = [];
+    steveServers.forEach(server => {
+        const url = server.replace('http', 'ws') + '/v1/subscribe';
+        const res = ws.connect(url, {cookies: data.cookies}, function(socket) {
+            socket.on('open', () => {
+                socket.send(JSON.stringify({
+                    resourceType: resource,
+                    namespace: namespace,
+                    mode: watchMode,
+                }));
+            });
+
+            socket.on('message', (message) => {
+                const event = JSON.parse(message);
+                if (event.name === 'resource.change') {
+                    const now = new Date().getTime();
+                    const resourceName = event.data.metadata.name;
+                    if (!changeEvents[resourceName]) {
+                        changeEvents[resourceName] = [];
+                    }
+                    changeEvents[resourceName].push(now);
+
+                    if (changeEvents[resourceName].length === steveServers.length) {
+                        const events = changeEvents[resourceName];
+                        const first = Math.min(...events);
+                        const last = Math.max(...events);
+                        deltaFastestSlowest.add(last - first);
+                        if(lastChangeTime) {
+                            delayFirstObserver.add(first - lastChangeTime);
+                            delayLastObserver.add(last - lastChangeTime);
+                        }
+                        delete changeEvents[resourceName];
+                    }
+                }
+            });
+
+            socket.on('close', () => console.log(`disconnected from ${url}`));
+            socket.on('error', function (e) {
+                if (e.error() != 'websocket: close sent') {
+                    console.log('An unexpected error occured: ', e.error());
+                }
+            });
+        });
+        check(res, { 'status is 101': (r) => r && r.status === 101 });
+        sockets.push(res);
+    });
+
+    sleep(60); // Watch for 60 seconds
+}
+
+export function changeScenario(data) {
+    const configMapId = Math.floor(Math.random() * numConfigMaps);
+    const serverId = Math.floor(Math.random() * steveServers.length);
+    const server = steveServers[serverId];
+    const name = `test-config-map-${configMapId}`;
+
+    const getRes = http.get(`${server}/v1/configmaps/${namespace}/${name}`, {cookies: data.cookies});
+    if (getRes.status !== 200) {
+        fail(`Failed to get configmap ${name}: ${getRes.status} ${getRes.body}`);
+    }
+    const configmap = JSON.parse(getRes.body);
+
+    configmap.data.data = `updated-${new Date().getTime()}`;
+
+    lastChangeTime = new Date().getTime();
+    const putRes = http.put(`${server}/v1/configmaps/${namespace}/${name}`, JSON.stringify(configmap), {
+        headers: { 'Content-Type': 'application/json' },
+        cookies: data.cookies
+    });
+    check(putRes, {
+        'update configmap returns 200': (r) => r.status === 200,
+    });
+}
+
+export function handleSummary(data) {
+    return {
+        'stdout': textSummary(data, { indent: ' ', enableColors: true }),
+    };
+}

--- a/k6/tests/steve_watch_benchmark.js
+++ b/k6/tests/steve_watch_benchmark.js
@@ -106,7 +106,10 @@ export function setup() {
             'create configmap returns 201': (r) => r.status === 201,
         })
     }
-    console.log('Setup complete');
+
+    const sleepTime = numConfigMaps / 100;
+    console.log(`Setup complete. Waiting ${sleepTime}s for informers to catch up`);
+    sleep(sleepTime);
     return { cookies: cookies };
 }
 

--- a/k6/tests/steve_watch_benchmark.js
+++ b/k6/tests/steve_watch_benchmark.js
@@ -148,23 +148,20 @@ export async function watchScenario(data) {
 
         ws.addEventListener('message', (e) => {
             const event = JSON.parse(e.data);
-            console.log(`Received event: ${event.name}`);
             if (event.name === 'resource.change') {
                 const now = new Date().getTime();
                 const delay = now - parseInt(event.data.data.data);
                 const resourceName = event.data.metadata.name;
-                console.log(`Processing change for ${resourceName}`);
                 if (!changeEvents[resourceName]) {
                     // this is the first server processing the event for this resource
                     changeEvents[resourceName] = [];
 
-                    console.log(`First server caught up on ${resourceName}. Delay: ${delay}ms`);
                     delayFirstObserver.add(delay)
                 }
                 changeEvents[resourceName].push(now);
+                console.log(`Server ${changeEvents[resourceName].length}/${steveServers.length} caught up on ${resourceName}. Delay: ${delay}ms`);
 
                 if (changeEvents[resourceName].length === steveServers.length) {
-                    console.log(`Last server caught up on ${resourceName}. Delay: ${delay}ms`);
                     delayLastObserver.add(delay);
 
                     const events = changeEvents[resourceName];

--- a/k6/tests/steve_watch_benchmark.js
+++ b/k6/tests/steve_watch_benchmark.js
@@ -13,7 +13,7 @@ const changeRate = __ENV.CHANGE_RATE || 1;
 const watchMode = __ENV.WATCH_MODE || ''; // "" for full resource, "resource.changes" for notifications
 const numConfigMaps = __ENV.CONFIG_MAP_COUNT || 100;
 const vus = __ENV.K6_VUS || 1;
-const iterations = __ENV.PER_VU_ITERATIONS || 10;
+const watchDuration = __ENV.WATCH_DURATION || 30;
 
 const username = __ENV.USERNAME;
 const password = __ENV.PASSWORD;
@@ -32,16 +32,16 @@ export const options = {
             executor: 'per-vu-iterations',
             exec: 'watchScenario',
             vus: vus,
-            iterations: iterations,
-            maxDuration: '24h',
+            iterations: 1,
+            maxDuration: watchDuration * 2 + 's',
         },
         change: {
             executor: 'constant-arrival-rate',
             exec: 'changeScenario',
             rate: changeRate,
             timeUnit: '1s',
-            duration: '24h',
-            preAllocatedVUs: 1,
+            duration: watchDuration + 's',
+            preAllocatedVUs: 10,
         },
     },
     thresholds: {
@@ -161,7 +161,8 @@ export function watchScenario(data) {
         sockets.push(res);
     });
 
-    sleep(60); // Watch for 60 seconds
+    console.log(`Watching for ${watchDuration} seconds`);
+    sleep(watchDuration);
 }
 
 export function changeScenario(data) {

--- a/k6/tests/steve_watch_benchmark.js
+++ b/k6/tests/steve_watch_benchmark.js
@@ -33,7 +33,7 @@ export const options = {
             exec: 'watchScenario',
             vus: vus,
             iterations: 1,
-            maxDuration: watchDuration * 2 + 's',
+            maxDuration: watchDuration + 's',
         },
         change: {
             executor: 'constant-arrival-rate',
@@ -158,13 +158,17 @@ export function watchScenario(data) {
                     console.log('An unexpected error occured: ', e.error());
                 }
             });
+
+            socket.setTimeout(function () {
+                console.log(`Closing socket to ${url}`)
+                socket.close();
+            }, watchDuration * 1000);
         });
         check(res, { 'status is 101': (r) => r && r.status === 101 });
         sockets.push(res);
     });
 
-    console.log(`Watching for ${watchDuration} seconds`);
-    sleep(watchDuration);
+    console.log("Done watching");
 }
 
 export function changeScenario(data) {

--- a/k6/tests/steve_watch_benchmark.js
+++ b/k6/tests/steve_watch_benchmark.js
@@ -117,7 +117,9 @@ export function watchScenario(data) {
     const sockets = [];
     steveServers.forEach(server => {
         const url = server.replace('http', 'ws') + '/v1/subscribe';
-        const res = ws.connect(url, {cookies: data.cookies}, function(socket) {
+        const jar = http.cookieJar();
+        jar.set(server, "R_SESS", data.cookies["R_SESS"]);
+        const res = ws.connect(url, {jar: jar}, function(socket) {
             socket.on('open', () => {
                 socket.send(JSON.stringify({
                     resourceType: resource,


### PR DESCRIPTION
This pull request introduces a new k6 benchmark test for the Steve Watch API.

The test is designed to measure the relative lag of multiple SQLite Steve replicas via the Watch API by simulating multiple clients watching for changes while those resources are being updated at a
  configurable rate.

*Key Features*:

   * **Multiple Steve Servers**: The test is designed to target multiple Steve pods, allowing for the measurement of event propagation delays between servers.
   * **Ad-Hoc Metrics**: The test collects:
       * `delta_fastest_slowest`: The time difference between the fastest and slowest server to report a change.
       * `delay_first_observer`: The time between a resource change and the first server reporting the change.
       * `delay_last_observer`: The time between a resource change and the last server reporting the change.
   * **Non-Blocking WebSockets**: The test uses the experimental, non-blocking WebSocket API to ensure that it can handle a large number of concurrent connections.

How to Run:

```sh
k6 run -e STEVE_SERVERS=https://10.42.135.12,https://10.42.11.197,https://10.42.159.101 -e TOKEN=$RANCHER_TOKEN -e CONFIG_MAP_COUNT=1000 -e CHANGE_RATE=5 -e WATCH_DURATION=600 ./steve_watch_benchmark.js
```

Note 10.42.135.12, 10.42.11.197, 10.42.159.101 are example Pod IPs (`rancher` or `cattle-cluster-agent`).


**Reviewer note: it might be interesting to you to look at this commit-by-commit**