### PR TITLE
Make the AWS module's network more secure

### DIFF
--- a/tofu/main/aws/main.tf
+++ b/tofu/main/aws/main.tf
@@ -13,6 +13,7 @@ module "network" {
   ssh_bastion_user     = var.ssh_bastion_user
   ssh_public_key_path  = var.ssh_public_key_path
   ssh_private_key_path = var.ssh_private_key_path
+  ssh_prefix_list      = var.ssh_prefix_list
 }
 
 module "test_environment" {

--- a/tofu/main/aws/terraform.tf
+++ b/tofu/main/aws/terraform.tf
@@ -3,15 +3,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.74.0"
+      version = "6.9.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "4.0.3"
+      version = "4.1.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.7.1"
+      version = "3.0.2"
     }
     ssh = {
       source  = "loafoe/ssh"

--- a/tofu/main/aws/variables.tf
+++ b/tofu/main/aws/variables.tf
@@ -18,6 +18,12 @@ variable "ssh_bastion_user" {
   default     = "root"
 }
 
+variable "ssh_prefix_list" {
+  description = "The name of an existing prefix list of IP addresses approved for SSH access"
+  type = string
+  default = null
+}
+
 variable "upstream_cluster" {
   description = "Upstream cluster configuration. See tofu/modules/generic/test_environment/variables.tf for details"
   type        = any

--- a/tofu/modules/aws/network/main.tf
+++ b/tofu/modules/aws/network/main.tf
@@ -210,7 +210,6 @@ resource "aws_vpc_security_group_ingress_rule" "vpc_ssh" {
 resource "aws_vpc_security_group_ingress_rule" "vpc_ssh_cidrs" {
   for_each = toset([
     "3.0.0.0/8", "52.0.0.0/8", "13.0.0.0/8", "18.0.0.0/8",
-    "54.202.233.179/32", "18.236.88.177/32", "34.217.178.224/32"
   ])
   description       = "SSH from Approved CIDR range (${each.value})"
   from_port         = 22

--- a/tofu/modules/aws/network/main.tf
+++ b/tofu/modules/aws/network/main.tf
@@ -171,6 +171,7 @@ resource "aws_vpc_dhcp_options_association" "vpc_dhcp_options" {
 }
 
 data "aws_ec2_managed_prefix_list" "this" {
+  count = var.ssh_prefix_list != null ? 1 : 0
   name = var.ssh_prefix_list
 }
 
@@ -190,9 +191,10 @@ resource "aws_security_group" "ssh_ipv4" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "prefix_ipv4" {
+  count             = var.ssh_prefix_list != null ? 1 : 0
   description       = "SSH access for Approved Prefix List Public IPv4s"
   ip_protocol       = "-1"
-  prefix_list_id    = data.aws_ec2_managed_prefix_list.this.id
+  prefix_list_id    = data.aws_ec2_managed_prefix_list.this[0].id
   security_group_id = aws_security_group.ssh_ipv4.id
 }
 

--- a/tofu/modules/aws/network/main.tf
+++ b/tofu/modules/aws/network/main.tf
@@ -170,38 +170,109 @@ resource "aws_vpc_dhcp_options_association" "vpc_dhcp_options" {
   dhcp_options_id = aws_vpc_dhcp_options.dhcp_options[0].id
 }
 
+data "aws_ec2_managed_prefix_list" "this" {
+  name = var.ssh_prefix_list
+}
+
+resource "aws_security_group" "ssh_ipv4" {
+  name        = "ssh_ipv4"
+  description = "Enables SSH access for approved CIDR ranges and specific IPs"
+  vpc_id      = local.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Project = var.project_name
+    Name    = "${var.project_name}-public-security-group"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "prefix_ipv4" {
+  description       = "SSH access for Approved Prefix List Public IPv4s"
+  ip_protocol       = "-1"
+  prefix_list_id    = data.aws_ec2_managed_prefix_list.this.id
+  security_group_id = aws_security_group.ssh_ipv4.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "vpc_ssh" {
+  description       = "Default VPC IPv4"
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+  cidr_ipv4         = local.vpc_cidr_block
+  security_group_id = aws_security_group.ssh_ipv4.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "vpc_ssh_cidrs" {
+  for_each = toset([
+    "3.0.0.0/8", "52.0.0.0/8", "13.0.0.0/8", "18.0.0.0/8",
+    "54.202.233.179/32", "18.236.88.177/32", "34.217.178.224/32"
+  ])
+  description       = "SSH from Approved CIDR range (${each.value})"
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+  cidr_ipv4         = each.value
+  security_group_id = aws_security_group.ssh_ipv4.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "public_https" {
+  description       = "Allow HTTPS from all sources"
+  security_group_id = aws_security_group.public.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "public_vpc_cidr" {
+  description       = "Allow all traffic from VPC CIDR"
+  security_group_id = aws_security_group.public.id
+  cidr_ipv4         = local.vpc_cidr_block
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}
+
+resource "aws_vpc_security_group_ingress_rule" "public_internal_traffic" {
+  description = "Allow all internal traffic within this SG"
+  security_group_id = aws_security_group.public.id
+  referenced_security_group_id = aws_security_group.public.id
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}
+
+resource "aws_vpc_security_group_egress_rule" "public_traffic_ipv4" {
+  description = "Allow all egress traffic"
+  security_group_id = aws_security_group.public.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}
+
+resource "aws_vpc_security_group_ingress_rule" "private_vpc_cidr" {
+  description       = "Allow all traffic from VPC CIDR"
+  security_group_id = aws_security_group.private.id
+  cidr_ipv4         = local.vpc_cidr_block
+  ip_protocol       = "-1"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "private_internal_traffic" {
+  description = "Allow all internal traffic within this SG"
+  security_group_id = aws_security_group.private.id
+  referenced_security_group_id = aws_security_group.private.id
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}
+
+resource "aws_vpc_security_group_egress_rule" "private_traffic_ipv4" {
+  description = "Allow all egress traffic"
+  security_group_id = aws_security_group.private.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}
+
 resource "aws_security_group" "public" {
   name        = "${var.project_name}-public-security-group"
   description = "Allow inbound connections from the VPC; allow connections on ports 22 (SSH) and 443 (HTTPS); allow all outbound connections"
   vpc_id      = local.vpc_id
-
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = [local.vpc_cidr_block]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 
   lifecycle {
     create_before_destroy = true
@@ -217,20 +288,6 @@ resource "aws_security_group" "private" {
   name        = "${var.project_name}-private-security-group"
   description = "Allow all inbound and outbound connections within the VPC"
   vpc_id      = local.vpc_id
-
-  ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = [local.vpc_cidr_block]
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 
   lifecycle {
     create_before_destroy = true
@@ -263,6 +320,7 @@ module "bastion" {
     secondary_private_subnet_id : local.secondary_private_subnet_id
     public_security_group_id : aws_security_group.public.id
     private_security_group_id : aws_security_group.private.id
+    other_security_group_ids : [aws_security_group.ssh_ipv4.id]
     ssh_key_name : aws_key_pair.key_pair.key_name
     ssh_bastion_host : null
     ssh_bastion_user : null

--- a/tofu/modules/aws/network/outputs.tf
+++ b/tofu/modules/aws/network/outputs.tf
@@ -6,6 +6,7 @@ output "config" {
     secondary_private_subnet_id : local.secondary_private_subnet_id,
     public_security_group_id : aws_security_group.public.id,
     private_security_group_id : aws_security_group.private.id,
+    other_security_group_ids: [aws_security_group.ssh_ipv4.id],
     ssh_key_name : aws_key_pair.key_pair.key_name,
     ssh_bastion_host : module.bastion.public_name,
     ssh_bastion_user : var.ssh_bastion_user,

--- a/tofu/modules/aws/network/variables.tf
+++ b/tofu/modules/aws/network/variables.tf
@@ -29,6 +29,12 @@ variable "ssh_private_key_path" {
   type        = string
 }
 
+variable "ssh_prefix_list" {
+  description = "The name of an existing prefix list of IP addresses approved for SSH access"
+  type = string
+  default = null
+}
+
 variable "ssh_bastion_user" {
   description = "User name to use for the SSH connection to the bastion host"
   type        = string

--- a/tofu/modules/aws/node/main.tf
+++ b/tofu/modules/aws/node/main.tf
@@ -5,7 +5,7 @@ resource "aws_instance" "instance" {
   key_name               = var.network_config.ssh_key_name
   subnet_id              = var.public ? var.network_config.public_subnet_id : var.network_config.private_subnet_id
   vpc_security_group_ids = distinct(concat([
-    var.public ? var.network_config.public_security_group_id : var.network_config.private_security_group_id], [var.network_config.private_security_group_id], var.network_config.other_security_group_ids))
+    var.public ? var.network_config.public_security_group_id : var.network_config.private_security_group_id], var.network_config.other_security_group_ids))
 
   root_block_device {
     volume_size = var.node_module_variables.root_volume_size_gb

--- a/tofu/modules/aws/node/main.tf
+++ b/tofu/modules/aws/node/main.tf
@@ -4,7 +4,8 @@ resource "aws_instance" "instance" {
   availability_zone      = var.network_config.availability_zone
   key_name               = var.network_config.ssh_key_name
   subnet_id              = var.public ? var.network_config.public_subnet_id : var.network_config.private_subnet_id
-  vpc_security_group_ids = [var.public ? var.network_config.public_security_group_id : var.network_config.private_security_group_id]
+  vpc_security_group_ids = distinct(concat([
+    var.public ? var.network_config.public_security_group_id : var.network_config.private_security_group_id], [var.network_config.private_security_group_id], var.network_config.other_security_group_ids))
 
   root_block_device {
     volume_size = var.node_module_variables.root_volume_size_gb

--- a/tofu/modules/aws/node/outputs.tf
+++ b/tofu/modules/aws/node/outputs.tf
@@ -12,7 +12,7 @@ output "private_ip" {
 }
 
 output "public_ip" {
-  value = var.public ? aws_instance.instance.public_ip : aws_instance.instance.private_ip
+  value = aws_instance.instance.public_ip
 }
 
 output "public_name" {

--- a/tofu/modules/aws/node/variables.tf
+++ b/tofu/modules/aws/node/variables.tf
@@ -67,6 +67,7 @@ variable "network_config" {
     secondary_private_subnet_id : string,
     public_security_group_id : string,
     private_security_group_id : string,
+    other_security_group_ids: optional(list(string), [""])
     ssh_key_name : string,
     ssh_bastion_host : string,
     ssh_bastion_user : string,

--- a/tofu/modules/generic/k3s/install_k3s.sh
+++ b/tofu/modules/generic/k3s/install_k3s.sh
@@ -76,10 +76,10 @@ RETRY_DELAY=5 # seconds
 status=1
 for (( i=1; i<=MAX_RETRIES; i++ )); do
   if [ -f "${get_k3s_path}" ]; then
-      sh /tmp/get_k3s.sh
+      sudo -s INSTALL_K3S_VERSION=${distro_version} sh -x /tmp/get_k3s.sh
       status=$?
   else
-      curl -sfL https://get.k3s.io | sh -
+      sudo -s curl -sfL https://get.k3s.io | sh -
       status=$?
   fi
 

--- a/tofu/modules/generic/k3s/install_k3s.sh
+++ b/tofu/modules/generic/k3s/install_k3s.sh
@@ -6,7 +6,7 @@ set -xe
 # can be removed as of v1.27.2+k3s1 and later
 sleep ${sleep_time}
 
-# sudo -s <<SUDO
+sudo -s <<SUDO
 # use data disk if available (see mount_ephemeral.sh)
 if [ -d /data ]; then
   mkdir -p /data/rancher
@@ -76,10 +76,10 @@ RETRY_DELAY=5 # seconds
 status=1
 for (( i=1; i<=MAX_RETRIES; i++ )); do
   if [ -f "${get_k3s_path}" ]; then
-      sudo -s INSTALL_K3S_VERSION=${distro_version} sh -x /tmp/get_k3s.sh
+      INSTALL_K3S_VERSION=${distro_version} sh -x /tmp/get_k3s.sh
       status=$?
   else
-      sudo -s curl -sfL https://get.k3s.io | sh -
+      curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${distro_version} sh -x -
       status=$?
   fi
 
@@ -95,4 +95,4 @@ if [ $i -gt $MAX_RETRIES ]; then
     echo "Command failed after $MAX_RETRIES attempts."
     exit 1
 fi
-# SUDO
+SUDO

--- a/tofu/modules/generic/k3s/install_k3s.sh
+++ b/tofu/modules/generic/k3s/install_k3s.sh
@@ -2,11 +2,6 @@
 
 set -xe
 
-# HACK: work around https://github.com/k3s-io/k3s/issues/7000
-# can be removed as of v1.27.2+k3s1 and later
-sleep ${sleep_time}
-
-sudo -s <<SUDO
 # use data disk if available (see mount_ephemeral.sh)
 if [ -d /data ]; then
   mkdir -p /data/rancher
@@ -36,8 +31,12 @@ EOF
 
 mkdir -p /etc/rancher/k3s/
 cat >/etc/rancher/k3s/config.yaml <<EOF
+%{ if server_url != null }
 server: ${jsonencode(server_url)}
+%{ endif ~}
+%{ if token != null }
 token: ${jsonencode(token)}
+%{ endif ~}
 %{ if cluster_init ~}
 cluster-init: true
 %{ endif ~}
@@ -76,10 +75,10 @@ RETRY_DELAY=5 # seconds
 status=1
 for (( i=1; i<=MAX_RETRIES; i++ )); do
   if [ -f "${get_k3s_path}" ]; then
-      INSTALL_K3S_VERSION=${distro_version} sh -x /tmp/get_k3s.sh
+      sh /tmp/get_k3s.sh
       status=$?
   else
-      curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${distro_version} sh -x -
+      curl -sfL https://get.k3s.io | sh -
       status=$?
   fi
 
@@ -95,4 +94,3 @@ if [ $i -gt $MAX_RETRIES ]; then
     echo "Command failed after $MAX_RETRIES attempts."
     exit 1
 fi
-SUDO

--- a/tofu/modules/generic/k3s/main.tf
+++ b/tofu/modules/generic/k3s/main.tf
@@ -86,7 +86,6 @@ resource "ssh_sensitive_resource" "first_server_installation" {
       server_ca_cert         = tls_self_signed_cert.server_ca_cert.cert_pem
       request_header_ca_key  = tls_private_key.request_header_ca_key.private_key_pem
       request_header_ca_cert = tls_self_signed_cert.request_header_ca_cert.cert_pem
-      sleep_time             = 0
       max_pods               = var.max_pods
       node_cidr_mask_size    = var.node_cidr_mask_size
       datastore_endpoint     = var.datastore_endpoint
@@ -143,7 +142,6 @@ resource "ssh_resource" "additional_server_installation" {
       server_ca_cert         = tls_self_signed_cert.server_ca_cert.cert_pem
       request_header_ca_key  = tls_private_key.request_header_ca_key.private_key_pem
       request_header_ca_cert = tls_self_signed_cert.request_header_ca_cert.cert_pem
-      sleep_time             = count.index * 60
       max_pods               = var.max_pods
       node_cidr_mask_size    = var.node_cidr_mask_size
       datastore_endpoint     = var.datastore_endpoint
@@ -196,7 +194,6 @@ resource "ssh_resource" "agent_installation" {
       server_ca_cert         = tls_self_signed_cert.server_ca_cert.cert_pem
       request_header_ca_key  = tls_private_key.request_header_ca_key.private_key_pem
       request_header_ca_cert = tls_self_signed_cert.request_header_ca_cert.cert_pem
-      sleep_time             = 0
       max_pods               = var.max_pods
       node_cidr_mask_size    = var.node_cidr_mask_size
       datastore_endpoint     = var.datastore_endpoint

--- a/tofu/modules/generic/k3s/outputs.tf
+++ b/tofu/modules/generic/k3s/outputs.tf
@@ -9,7 +9,7 @@ output "config" {
       public = var.server_count > 0 ? "https://${module.server_nodes[0].public_name}:6443" : null
       // resolvable from the network this cluster runs in
       private = var.server_count > 0 ? "https://${module.server_nodes[0].private_name}:6443" : null
-      // resolvable from the host running OpenTofu
+      // resolvable from the host running OpenTofu when create_tunnels == true
       tunnel = local.local_kubernetes_api_url
     }
 
@@ -25,11 +25,11 @@ output "config" {
         http_port  = 80
         https_port = 443
       }
-      tunnel = { // resolvable from the host running OpenTofu
+      tunnel = var.create_tunnels ?  { // resolvable from the host running OpenTofu when var.create_tunnels == true
         name       = "${var.name}.local.gd"
         http_port  = var.tunnel_app_http_port
         https_port = var.tunnel_app_https_port
-      }
+      } : null
     }
 
     node_access_commands = merge({
@@ -39,5 +39,7 @@ output "config" {
     })
     ingress_class_name          = null
     reserve_node_for_monitoring = var.reserve_node_for_monitoring
+    server_nodes = module.server_nodes
+    agent_nodes = module.agent_nodes
   }
 }

--- a/tofu/modules/generic/k3s/variables.tf
+++ b/tofu/modules/generic/k3s/variables.tf
@@ -65,6 +65,12 @@ variable "sans" {
   default     = []
 }
 
+variable "create_tunnels" {
+  description = "Flag determining if we should create any SSH tunnels at all."
+  type = bool
+  default = false
+}
+
 variable "max_pods" {
   description = "Maximum number of pods per node"
   type        = number
@@ -86,6 +92,11 @@ variable "datastore_endpoint" {
   description = "Override datastore with a custom endpoint string"
   type        = string
   default     = null
+}
+
+variable "public" {
+  description = "Whether the node is publicly accessible"
+  default     = false
 }
 
 variable "node_module" {

--- a/tofu/modules/generic/node/outputs.tf
+++ b/tofu/modules/generic/node/outputs.tf
@@ -10,10 +10,22 @@ output "public_name" {
   value = module.host.public_name
 }
 
+output "public_ip" {
+  value = module.host.public_ip
+}
+
 output "name" {
   value = var.name
 }
 
 output "ssh_script_filename" {
   value = local_file.ssh_script.filename
+}
+
+output "ssh_user" {
+  value = module.host.ssh_user
+}
+
+output "ssh_key_path" {
+  value = module.host.ssh_key_path
 }

--- a/tofu/modules/generic/rke2/install_rke2.sh
+++ b/tofu/modules/generic/rke2/install_rke2.sh
@@ -2,9 +2,6 @@
 
 set -xe
 
-# HACK: work around https://github.com/k3s-io/k3s/issues/2306
-sleep ${sleep_time}
-
 mkdir -p /tmp/rke2-artifacts
 pushd /tmp/rke2-artifacts
   version=$(echo "${distro_version}" | sed 's/+/%2B/g')
@@ -15,7 +12,6 @@ pushd /tmp/rke2-artifacts
   wget -c https://prime.ribs.rancher.io/rke2/"$version"/sha256sum-amd64.txt
 popd
 
-sudo -s <<SUDO
 # use data disk if available (see mount_ephemeral.sh)
 if [ -d /data ]; then
   mkdir -p /data/rancher
@@ -60,8 +56,12 @@ EOF
 
 mkdir -p /etc/rancher/rke2/
 cat >/etc/rancher/rke2/config.yaml <<EOF
+%{ if server_url != null }
 server: ${jsonencode(server_url)}
+%{ endif ~}
+%{ if token != null }
 token: ${jsonencode(token)}
+%{ endif ~}
 %{ for label in labels ~}
 node-label: ${label.key}=${label.value}
 %{ endfor ~}
@@ -145,4 +145,4 @@ fi
 
 systemctl enable rke2-${type}.service
 systemctl restart rke2-${type}.service
-SUDO
+

--- a/tofu/modules/generic/rke2/install_rke2.sh
+++ b/tofu/modules/generic/rke2/install_rke2.sh
@@ -15,7 +15,7 @@ pushd /tmp/rke2-artifacts
   wget -c https://prime.ribs.rancher.io/rke2/"$version"/sha256sum-amd64.txt
 popd
 
-# sudo -s <<SUDO
+sudo -s <<SUDO
 # use data disk if available (see mount_ephemeral.sh)
 if [ -d /data ]; then
   mkdir -p /data/rancher
@@ -145,4 +145,4 @@ fi
 
 systemctl enable rke2-${type}.service
 systemctl restart rke2-${type}.service
-# SUDO
+SUDO

--- a/tofu/modules/generic/rke2/install_rke2.sh
+++ b/tofu/modules/generic/rke2/install_rke2.sh
@@ -127,7 +127,7 @@ for (( i=1; i<=MAX_RETRIES; i++ )); do
       status=$?
   fi
 
-  INSTALL_RKE2_ARTIFACT_PATH=/tmp/rke2-artifacts sh install.sh
+  sudo -s INSTALL_RKE2_ARTIFACT_PATH=/tmp/rke2-artifacts sh install.sh
   status=$?
 
   if [ $status -eq 0 ]; then

--- a/tofu/modules/generic/rke2/main.tf
+++ b/tofu/modules/generic/rke2/main.tf
@@ -85,7 +85,6 @@ resource "ssh_sensitive_resource" "first_server_installation" {
       server_ca_cert         = tls_self_signed_cert.server_ca_cert.cert_pem
       request_header_ca_key  = tls_private_key.request_header_ca_key.private_key_pem
       request_header_ca_cert = tls_self_signed_cert.request_header_ca_cert.cert_pem
-      sleep_time             = 0
       max_pods               = var.max_pods
       node_cidr_mask_size    = var.node_cidr_mask_size
     })
@@ -140,7 +139,6 @@ resource "ssh_resource" "additional_server_installation" {
       server_ca_cert         = tls_self_signed_cert.server_ca_cert.cert_pem
       request_header_ca_key  = tls_private_key.request_header_ca_key.private_key_pem
       request_header_ca_cert = tls_self_signed_cert.request_header_ca_cert.cert_pem
-      sleep_time             = count.index * 60
       max_pods               = var.max_pods
       node_cidr_mask_size    = var.node_cidr_mask_size
     })
@@ -191,7 +189,6 @@ resource "ssh_resource" "agent_installation" {
       server_ca_cert         = tls_self_signed_cert.server_ca_cert.cert_pem
       request_header_ca_key  = tls_private_key.request_header_ca_key.private_key_pem
       request_header_ca_cert = tls_self_signed_cert.request_header_ca_cert.cert_pem
-      sleep_time             = 0
       max_pods               = var.max_pods
       node_cidr_mask_size    = var.node_cidr_mask_size
     })

--- a/tofu/modules/generic/rke2/main.tf
+++ b/tofu/modules/generic/rke2/main.tf
@@ -6,6 +6,22 @@ terraform {
   }
 }
 
+data "http" "get_rke2" {
+  url = "https://get.rke2.io"
+
+  retry {
+    attempts = 5
+    min_delay_ms = 500
+    max_delay_ms = 3000
+  }
+
+  lifecycle {
+    postcondition {
+      condition     = contains([200], self.status_code)
+      error_message = "Status code invalid"
+    }
+  }
+}
 
 module "server_nodes" {
   count                = var.server_count
@@ -14,7 +30,7 @@ module "server_nodes" {
   name                 = "${var.name}-server-${count.index}"
   ssh_private_key_path = var.ssh_private_key_path
   ssh_user             = var.ssh_user
-  ssh_tunnels = count.index == 0 ? [
+  ssh_tunnels = count.index == 0 && var.create_tunnels ? [
     [var.local_kubernetes_api_port, 6443],
     [var.tunnel_app_http_port, 80],
     [var.tunnel_app_https_port, 443],
@@ -22,6 +38,7 @@ module "server_nodes" {
   node_module           = var.node_module
   node_module_variables = var.node_module_variables
   network_config        = var.network_config
+  public                = var.public
 }
 
 module "agent_nodes" {
@@ -46,7 +63,14 @@ resource "ssh_sensitive_resource" "first_server_installation" {
   timeout      = "600s"
 
   file {
+    content = data.http.get_rke2.response_body
+    destination = "${local.get_rke2_path}"
+    permissions = "0700"
+  }
+
+  file {
     content = templatefile("${path.module}/install_rke2.sh", {
+      get_rke2_path  = local.get_rke2_path
       distro_version = var.distro_version,
       sans           = concat([module.server_nodes[0].private_name], var.sans)
       type           = "server"
@@ -94,7 +118,14 @@ resource "ssh_resource" "additional_server_installation" {
   timeout      = "600s"
 
   file {
+    content = data.http.get_rke2.response_body
+    destination = "${local.get_rke2_path}"
+    permissions = "0700"
+  }
+
+  file {
     content = templatefile("${path.module}/install_rke2.sh", {
+      get_rke2_path  = local.get_rke2_path
       distro_version = var.distro_version,
       sans           = [module.server_nodes[count.index + 1].private_name]
       type           = "server"
@@ -134,7 +165,14 @@ resource "ssh_resource" "agent_installation" {
   timeout      = "600s"
 
   file {
+    content = data.http.get_rke2.response_body
+    destination = "${local.get_rke2_path}"
+    permissions = "0700"
+  }
+
+  file {
     content = templatefile("${path.module}/install_rke2.sh", {
+      get_rke2_path  = local.get_rke2_path
       distro_version = var.distro_version,
       sans           = [module.agent_nodes[count.index].private_name]
       type           = "agent"
@@ -167,7 +205,8 @@ resource "ssh_resource" "agent_installation" {
 }
 
 locals {
-  local_kubernetes_api_url = "https://${var.sans[0]}:${var.local_kubernetes_api_port}"
+  get_rke2_path   = "/tmp/get_rke2.sh"
+  local_kubernetes_api_url = var.create_tunnels ? "https://${var.sans[0]}:${var.local_kubernetes_api_port}" : "https://${module.server_nodes[0].public_name}:6443"
 }
 
 resource "local_file" "kubeconfig" {

--- a/tofu/modules/generic/rke2/outputs.tf
+++ b/tofu/modules/generic/rke2/outputs.tf
@@ -9,7 +9,7 @@ output "config" {
       public = var.server_count > 0 ? "https://${module.server_nodes[0].public_name}:6443" : null
       // resolvable from the network this cluster runs in
       private = var.server_count > 0 ? "https://${module.server_nodes[0].private_name}:6443" : null
-      // resolvable from the host running OpenTofu
+      // resolvable from the host running OpenTofu when create_tunnels == true
       tunnel = local.local_kubernetes_api_url
     }
 
@@ -25,11 +25,11 @@ output "config" {
         http_port  = 80
         https_port = 443
       }
-      tunnel = { // resolvable from the host running OpenTofu
+      tunnel = var.create_tunnels ?  { // resolvable from the host running OpenTofu when var.create_tunnels == true
         name       = "${var.name}.local.gd"
         http_port  = var.tunnel_app_http_port
         https_port = var.tunnel_app_https_port
-      }
+      } : null
     }
 
     node_access_commands = merge({
@@ -39,5 +39,7 @@ output "config" {
     })
     ingress_class_name          = null
     reserve_node_for_monitoring = var.reserve_node_for_monitoring
+    server_nodes = module.server_nodes
+    agent_nodes = module.agent_nodes
   }
 }

--- a/tofu/modules/generic/rke2/variables.tf
+++ b/tofu/modules/generic/rke2/variables.tf
@@ -66,6 +66,12 @@ variable "sans" {
   default     = []
 }
 
+variable "create_tunnels" {
+  description = "Flag determining if we should create any SSH tunnels at all."
+  type = bool
+  default = false
+}
+
 variable "max_pods" {
   description = "Maximum number of pods per node"
   type        = number
@@ -80,6 +86,11 @@ variable "node_cidr_mask_size" {
 
 variable "enable_audit_log" {
   description = "Ignored for RKE2"
+  default     = false
+}
+
+variable "public" {
+  description = "Whether the node is publicly accessible"
   default     = false
 }
 

--- a/tofu/modules/generic/test_environment/main.tf
+++ b/tofu/modules/generic/test_environment/main.tf
@@ -25,6 +25,8 @@ module "upstream_cluster" {
   distro_version              = var.upstream_cluster.distro_version
   reserve_node_for_monitoring = var.upstream_cluster.reserve_node_for_monitoring
   enable_audit_log            = var.upstream_cluster.enable_audit_log
+  create_tunnels              = var.upstream_cluster.create_tunnels
+  public                      = var.upstream_cluster.public_ip
 
   sans                      = ["upstream.local.gd"]
   local_kubernetes_api_port = var.first_kubernetes_api_port
@@ -35,7 +37,7 @@ module "upstream_cluster" {
   node_module               = var.node_module
   network_config            = var.network_config
   node_module_variables     = var.upstream_cluster.node_module_variables
-  datastore_endpoint        = var.upstream_cluster.postgres_node_variables != null ? module.upstream_postgres[0].datastore_endpoint : null
+  datastore_endpoint        = var.upstream_cluster.postgres_node_variables != {} ? module.upstream_postgres[0].datastore_endpoint : null
 }
 
 module "tester_cluster" {
@@ -48,6 +50,8 @@ module "tester_cluster" {
   distro_version              = var.tester_cluster.distro_version
   reserve_node_for_monitoring = var.tester_cluster.reserve_node_for_monitoring
   enable_audit_log            = var.tester_cluster.enable_audit_log
+  create_tunnels              = var.tester_cluster.create_tunnels
+  public                      = var.tester_cluster.public_ip
 
   sans                      = ["tester.local.gd"]
   local_kubernetes_api_port = var.first_kubernetes_api_port + 1
@@ -71,6 +75,8 @@ module "downstream_clusters" {
   distro_version              = local.downstream_clusters[count.index].distro_version
   reserve_node_for_monitoring = local.downstream_clusters[count.index].reserve_node_for_monitoring
   enable_audit_log            = local.downstream_clusters[count.index].enable_audit_log
+  create_tunnels              = local.downstream_clusters[count.index].create_tunnels
+  public                      = local.downstream_clusters[count.index].public_ip
 
   sans                      = ["${local.downstream_clusters[count.index].name}.local.gd"]
   local_kubernetes_api_port = var.first_kubernetes_api_port + 2 + count.index

--- a/tofu/modules/generic/test_environment/variables.tf
+++ b/tofu/modules/generic/test_environment/variables.tf
@@ -33,6 +33,7 @@ variable "upstream_cluster" {
     public_ip                   = bool // Whether the upstream cluster should have a public IP assigned
     reserve_node_for_monitoring = bool // Set a 'monitoring' label and taint on one node of the upstream cluster to reserve it for monitoring
     enable_audit_log            = bool // Enable audit log for the cluster
+    create_tunnels              = bool // Whether ssh tunnels to the downstream cluster's first server node should be created. Default false
     postgres_node_variables     = any  // Node module-specific variables for the Postgres-backed Kine
 
     node_module_variables = any // Node module-specific variables
@@ -55,9 +56,14 @@ variable "downstream_cluster_templates" {
     public_ip                   = bool // Whether the downstream cluster should have a public IP assigned
     reserve_node_for_monitoring = bool // Set a 'monitoring' label and taint on one node of the downstream cluster to reserve it for monitoring
     enable_audit_log            = bool // Enable audit log for the cluster
+    create_tunnels              = bool // Whether ssh tunnels to the downstream cluster's first server node should be created. Default false
 
     node_module_variables = any // Node module-specific variables
   }))
+  validation {
+    condition     = alltrue([for i, template in var.downstream_cluster_templates : template.cluster_count > 0 ? template.server_count > 0 ? true : false : true ])
+    error_message = "Must have at least one server per cluster template when cluster_count > 0."
+  }
 }
 
 # Note: this is kept constant for all templates because OpenTofu v1.8.2 does not allow to use
@@ -80,6 +86,7 @@ variable "tester_cluster" {
     public_ip                   = bool // Whether the tester cluster should have a public IP assigned
     reserve_node_for_monitoring = bool // Set a 'monitoring' label and taint on one node of the tester cluster to reserve it for monitoring
     enable_audit_log            = bool // Enable audit log for the cluster
+    create_tunnels              = bool // Whether ssh tunnels to the downstream cluster's first server node should be created. Default false
 
     node_module_variables = any // Node module-specific variables
   })                            # If null, no tester cluster will be created


### PR DESCRIPTION
- Updates the providers to the current latest
- Replaces security group rules and inline rules with `aws_vpc_security_group_ingress_rule` & `aws_vpc_security_group_egress_rule` 
  - see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group.html for context
- Added a new SG for ssh access, removed open access to ssh port
  - Added common EC2 ranges to the ssh access SG
- Added support for allowing addresses managed by a VPC prefix list to the "allowed" ssh SG
- Made changes to reduce the flakiness of `install_k3s.sh` and `install_rke2.sh`
- Made ssh tunnels toggleable

Note: `create_tunnels` should still be set to true for the tester cluster (and probably upstream) for AWS Dart files because the changes needed to make the certificates valid for the appropriate address/hostname have not been made in this PR.