### PR TITLE
Add max_pods and node_cidr_mask_size to test environment downstream clusters

### DIFF
--- a/tofu/modules/generic/test_environment/main.tf
+++ b/tofu/modules/generic/test_environment/main.tf
@@ -79,6 +79,8 @@ module "downstream_clusters" {
   public                      = local.downstream_clusters[count.index].public_ip
 
   sans                      = ["${local.downstream_clusters[count.index].name}.local.gd"]
+  max_pods                  = local.downstream_clusters[count.index].max_pods
+  node_cidr_mask_size       = local.downstream_clusters[count.index].node_cidr_mask_size
   local_kubernetes_api_port = var.first_kubernetes_api_port + 2 + count.index
   tunnel_app_http_port      = var.first_app_http_port + 2 + count.index
   tunnel_app_https_port     = var.first_app_https_port + 2 + count.index

--- a/tofu/modules/generic/test_environment/variables.tf
+++ b/tofu/modules/generic/test_environment/variables.tf
@@ -57,6 +57,8 @@ variable "downstream_cluster_templates" {
     reserve_node_for_monitoring = bool // Set a 'monitoring' label and taint on one node of the downstream cluster to reserve it for monitoring
     enable_audit_log            = bool // Enable audit log for the cluster
     create_tunnels              = bool // Whether ssh tunnels to the downstream cluster's first server node should be created. Default false
+    max_pods                    = number // Max pods per node
+    node_cidr_mask_size         = string // Number of IP addresses for pods per node
 
     node_module_variables = any // Node module-specific variables
   }))


### PR DESCRIPTION
There was no way to pass this to the modules, which already support it.