### PR TITLE
Update deploy logic

### DIFF
--- a/cmd/dartboard/subcommands/deploy.go
+++ b/cmd/dartboard/subcommands/deploy.go
@@ -176,14 +176,14 @@ func chartInstallRancher(r *dart.Dart, rancherImageTag string, cluster *tofu.Clu
 
 		// otherwise, if one of "alpha", or "latest"
 		if strings.Contains(r.ChartVariables.RancherVersion, "alpha") {
-			rancherRepo = baseRepo + "alpha"
+			rancherRepo = baseRepo + "alpha/rancher-"
 		} else {
-			rancherRepo = baseRepo + "latest"
+			rancherRepo = baseRepo + "latest/rancher-"
 		}
 
 		// "prime"
 		if r.ChartVariables.ForcePrimeRegistry {
-			rancherRepo = "https://charts.rancher.com/server-charts/prime"
+			rancherRepo = "https://charts.rancher.com/server-charts/prime/rancher-"
 		}
 
 	}


### PR DESCRIPTION
- Handle chart repo overide logic more cleanly
- Force rancher deployment name override to minimize further changes to the deploy code flow
  - This will enable us to pull charts from the proper repo anytime the way we deploy our rancher helm charts changes
- Especially helpful for the new location of rancher-prime charts, etc.