### PR TITLE
Update golang version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ ARG K6_VERSION="1.7.1"
 # renovate: datasource=docker depName=grafana/k6 digestVersion=1.7.1
 ARG K6_IMAGE_DIGEST="sha256:4fd3a694926b064d3491d9b02b01cde886583c4931f1223816e3d9a7bdfa7e0f"
 # renovate: datasource=docker depName=golang
-ARG GOLANG_VERSION="1.25-alpine3.22"
-# renovate: datasource=docker depName=golang digestVersion=1.25-alpine3.22
+ARG GOLANG_VERSION="1.25.10-alpine3.22"
+# renovate: datasource=docker depName=golang digestVersion=1.25.10-alpine3.22
 ARG GOLANG_IMAGE_DIGEST="sha256:26b4d7113039cd51356bd7930ecafd1031d2975dc3b6940ec8ed09457e17cf95"
 FROM golang:${GOLANG_VERSION}@${GOLANG_IMAGE_DIGEST} AS builder
 # match whichever tagged version is used by the K6_VERSION docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ ARG K6_VERSION="1.7.1"
 # renovate: datasource=docker depName=grafana/k6 digestVersion=1.7.1
 ARG K6_IMAGE_DIGEST="sha256:4fd3a694926b064d3491d9b02b01cde886583c4931f1223816e3d9a7bdfa7e0f"
 # renovate: datasource=docker depName=golang
-ARG GOLANG_VERSION="1.24.2-alpine3.21"
-# renovate: datasource=docker depName=golang digestVersion=1.24.2-alpine3.21
-ARG GOLANG_IMAGE_DIGEST="sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee"
+ARG GOLANG_VERSION="1.25-alpine3.22"
+# renovate: datasource=docker depName=golang digestVersion=1.25-alpine3.22
+ARG GOLANG_IMAGE_DIGEST="sha256:26b4d7113039cd51356bd7930ecafd1031d2975dc3b6940ec8ed09457e17cf95"
 FROM golang:${GOLANG_VERSION}@${GOLANG_IMAGE_DIGEST} AS builder
 # match whichever tagged version is used by the K6_VERSION docker image
 # see build layer at https://github.com/grafana/k6/blob/v${K6_VERSION}/Dockerfile


### PR DESCRIPTION
- golang version bump, needed for CI to run new cluster registration update on 1.25.0